### PR TITLE
Auto-bypass AGS scopes like variable/NV optics

### DIFF
--- a/ScopeLifecycle.cs
+++ b/ScopeLifecycle.cs
@@ -540,19 +540,32 @@ namespace ScopeHousingMeshSurgery
             string templateName = FovController.GetOpticTemplateName(os);
             string templateId = FovController.GetOpticTemplateId(os);
             string opticName = os.name;
+            string hierarchyMatch = FindAgsNameInHierarchy(os.transform);
 
             bool isAgs = ContainsCI(scopeKey, "ags")
                 || ContainsCI(templateName, "ags")
                 || ContainsCI(templateId, "ags")
-                || ContainsCI(opticName, "ags");
+                || ContainsCI(opticName, "ags")
+                || !string.IsNullOrEmpty(hierarchyMatch);
 
             if (isAgs)
             {
                 ScopeHousingMeshSurgeryPlugin.LogInfo(
-                    $"[ScopeLifecycle] AGS auto-bypass match: key='{scopeKey}' template='{templateName}' id='{templateId}' optic='{opticName}'");
+                    $"[ScopeLifecycle] AGS auto-bypass match: key='{scopeKey}' template='{templateName}' id='{templateId}' optic='{opticName}' hierarchy='{hierarchyMatch}'");
             }
 
             return isAgs;
+        }
+
+        private static string FindAgsNameInHierarchy(Transform start)
+        {
+            for (var t = start; t != null; t = t.parent)
+            {
+                if (ContainsCI(t.name, "ags"))
+                    return t.name;
+            }
+
+            return null;
         }
 
         private static void RefreshScopeWhitelistCache()

--- a/ScopeLifecycle.cs
+++ b/ScopeLifecycle.cs
@@ -504,7 +504,9 @@ namespace ScopeHousingMeshSurgery
                 return true;
 
             if (ScopeHousingMeshSurgeryPlugin.AutoDisableForVariableScopes.Value
-                && (FovController.IsOpticAdjustable(os) || IsThermalOrNightVisionOptic(os)))
+                && (FovController.IsOpticAdjustable(os)
+                    || IsThermalOrNightVisionOptic(os)
+                    || IsAgsOptic(os)))
                 return true;
 
             return false;
@@ -528,6 +530,29 @@ namespace ScopeHousingMeshSurgery
             }
 
             return !allowed;
+        }
+
+        private static bool IsAgsOptic(OpticSight os)
+        {
+            if (os == null) return false;
+
+            string scopeKey = ResolveWhitelistScopeKey(os);
+            string templateName = FovController.GetOpticTemplateName(os);
+            string templateId = FovController.GetOpticTemplateId(os);
+            string opticName = os.name;
+
+            bool isAgs = ContainsCI(scopeKey, "ags")
+                || ContainsCI(templateName, "ags")
+                || ContainsCI(templateId, "ags")
+                || ContainsCI(opticName, "ags");
+
+            if (isAgs)
+            {
+                ScopeHousingMeshSurgeryPlugin.LogInfo(
+                    $"[ScopeLifecycle] AGS auto-bypass match: key='{scopeKey}' template='{templateName}' id='{templateId}' optic='{opticName}'");
+            }
+
+            return isAgs;
         }
 
         private static void RefreshScopeWhitelistCache()


### PR DESCRIPTION
### Motivation
- Treat optics whose identifiers contain "ags" as scopes that should automatically bypass the mod, using the same criteria already used for adjustable (variable) and thermal/NV scopes.

### Description
- Updated `ShouldBypassForCurrentOptic` to include an `IsAgsOptic` check alongside `FovController.IsOpticAdjustable` and `IsThermalOrNightVisionOptic` in `ScopeLifecycle.cs`.
- Added a new helper `IsAgsOptic(OpticSight os)` that detects "ags" in the resolved scope key, template name, template id, or the optic object name and returns true when any contain "ags".
- Emits an informational log when an AGS match triggers the auto-bypass to aid debugging and tracing.
- Modified file: `ScopeLifecycle.cs`.

### Testing
- Ran repository scans and diffs to verify the changes were placed in `ScopeLifecycle.cs` and inspected the integrated code paths; textual verification succeeded.
- Committed the change (`git commit`) successfully to the local branch.
- Attempted `dotnet build` to compile the project but it could not be executed in the current environment because `dotnet` is not installed, so compilation was not verified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afe5d0491c83289c2f255ceaf6b0c5)