### PR TITLE
Move scope CommandBuffers to CameraEvent.BeforeImageEffects

### DIFF
--- a/ReticleRenderer.cs
+++ b/ReticleRenderer.cs
@@ -7,7 +7,7 @@ namespace ScopeHousingMeshSurgery
 {
     /// <summary>
     /// Renders the scope reticle via a CommandBuffer injected at
-    /// CameraEvent.AfterEverything on the main FPS camera.
+    /// CameraEvent.BeforeImageEffects on the main FPS camera.
     ///
     /// ── CAMERA ALIGNMENT APPROACH ───────────────────────────────────────
     /// The root cause of reticle jitter is the mismatch between where the
@@ -252,7 +252,7 @@ namespace ScopeHousingMeshSurgery
             if (_cmdBuffer == null)
                 _cmdBuffer = new CommandBuffer { name = "ScopeReticleOverlay" };
 
-            mainCam.AddCommandBuffer(CameraEvent.AfterEverything, _cmdBuffer);
+            mainCam.AddCommandBuffer(CameraEvent.BeforeImageEffects, _cmdBuffer);
             _attachedCamera = mainCam;
 
             if (!_preCullRegistered)
@@ -262,7 +262,7 @@ namespace ScopeHousingMeshSurgery
             }
 
             ScopeHousingMeshSurgeryPlugin.LogInfo(
-                $"[Reticle] CommandBuffer attached to '{mainCam.name}' at AfterEverything");
+                $"[Reticle] CommandBuffer attached to '{mainCam.name}' at BeforeImageEffects");
         }
 
         private static void DetachFromCamera()
@@ -275,7 +275,7 @@ namespace ScopeHousingMeshSurgery
 
             if (_attachedCamera != null && _cmdBuffer != null)
             {
-                try { _attachedCamera.RemoveCommandBuffer(CameraEvent.AfterEverything, _cmdBuffer); }
+                try { _attachedCamera.RemoveCommandBuffer(CameraEvent.BeforeImageEffects, _cmdBuffer); }
                 catch (System.Exception) { }
             }
 

--- a/ScopeEffectsRenderer.cs
+++ b/ScopeEffectsRenderer.cs
@@ -5,7 +5,7 @@ namespace ScopeHousingMeshSurgery
 {
     /// <summary>
     /// Renders scope vignette and shadow effects via a CommandBuffer injected at
-    /// CameraEvent.AfterEverything on Camera.main, using nonJitteredProjectionMatrix.
+    /// CameraEvent.BeforeImageEffects on Camera.main, using nonJitteredProjectionMatrix.
     ///
     /// This is the same technique as ReticleRenderer — both effects are drawn after
     /// all post-processing (TAA, DLSS, FSR) with explicitly non-jittered matrices,
@@ -144,7 +144,7 @@ namespace ScopeHousingMeshSurgery
             if (_cmdBuffer == null)
                 _cmdBuffer = new CommandBuffer { name = "ScopeEffectsOverlay" };
 
-            mainCam.AddCommandBuffer(CameraEvent.AfterEverything, _cmdBuffer);
+            mainCam.AddCommandBuffer(CameraEvent.BeforeImageEffects, _cmdBuffer);
             _attachedCamera = mainCam;
 
             if (!_preCullRegistered)
@@ -154,7 +154,7 @@ namespace ScopeHousingMeshSurgery
             }
 
             ScopeHousingMeshSurgeryPlugin.LogVerbose(
-                $"[ScopeEffects] CommandBuffer attached to '{mainCam.name}' at AfterEverything");
+                $"[ScopeEffects] CommandBuffer attached to '{mainCam.name}' at BeforeImageEffects");
         }
 
         private static void DetachFromCamera()
@@ -167,7 +167,7 @@ namespace ScopeHousingMeshSurgery
 
             if (_attachedCamera != null && _cmdBuffer != null)
             {
-                try { _attachedCamera.RemoveCommandBuffer(CameraEvent.AfterEverything, _cmdBuffer); }
+                try { _attachedCamera.RemoveCommandBuffer(CameraEvent.BeforeImageEffects, _cmdBuffer); }
                 catch (System.Exception) { }
             }
 


### PR DESCRIPTION
### Motivation
- Ensure scope overlays (reticle, vignette/shadow) are executed before post-processing so their non-jittered matrices and screen-space draws are not affected by image effects like TAA/DLSS/FSR.
- Align runtime behavior and logging/comments to the new injection timing (`CameraEvent.BeforeImageEffects`) for clarity and correctness.

### Description
- Updated `ReticleRenderer.cs` to attach and remove its `CommandBuffer` at `CameraEvent.BeforeImageEffects` instead of `CameraEvent.AfterEverything`, and updated the header comment and log message to match.
- Updated `ScopeEffectsRenderer.cs` to attach and remove its `CommandBuffer` at `CameraEvent.BeforeImageEffects` instead of `CameraEvent.AfterEverything`, and updated the header comment and verbose log message to match.
- Changes applied to both attach (`AddCommandBuffer`) and detach (`RemoveCommandBuffer`) calls and committed to the repository.

### Testing
- Attempted to run `dotnet build ScopeHousingMeshSurgery.sln`, which failed in this environment because `dotnet` is not installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aff02ec960832881e01407dfbff524)