### PR TITLE
Attach reticle CommandBuffer at BeforeImageEffects instead of AfterEverything

### DIFF
--- a/ReticleRenderer.cs
+++ b/ReticleRenderer.cs
@@ -7,7 +7,7 @@ namespace ScopeHousingMeshSurgery
 {
     /// <summary>
     /// Renders the scope reticle via a CommandBuffer injected at
-    /// CameraEvent.AfterEverything on the main FPS camera.
+    /// CameraEvent.BeforeImageEffects on the main FPS camera.
     ///
     /// ── CAMERA ALIGNMENT APPROACH ───────────────────────────────────────
     /// The root cause of reticle jitter is the mismatch between where the
@@ -252,7 +252,7 @@ namespace ScopeHousingMeshSurgery
             if (_cmdBuffer == null)
                 _cmdBuffer = new CommandBuffer { name = "ScopeReticleOverlay" };
 
-            mainCam.AddCommandBuffer(CameraEvent.AfterEverything, _cmdBuffer);
+            mainCam.AddCommandBuffer(CameraEvent.BeforeImageEffects, _cmdBuffer);
             _attachedCamera = mainCam;
 
             if (!_preCullRegistered)
@@ -262,7 +262,7 @@ namespace ScopeHousingMeshSurgery
             }
 
             ScopeHousingMeshSurgeryPlugin.LogInfo(
-                $"[Reticle] CommandBuffer attached to '{mainCam.name}' at AfterEverything");
+                $"[Reticle] CommandBuffer attached to '{mainCam.name}' at BeforeImageEffects");
         }
 
         private static void DetachFromCamera()
@@ -275,7 +275,7 @@ namespace ScopeHousingMeshSurgery
 
             if (_attachedCamera != null && _cmdBuffer != null)
             {
-                try { _attachedCamera.RemoveCommandBuffer(CameraEvent.AfterEverything, _cmdBuffer); }
+                try { _attachedCamera.RemoveCommandBuffer(CameraEvent.BeforeImageEffects, _cmdBuffer); }
                 catch (System.Exception) { }
             }
 

--- a/ScopeEffectsRenderer.cs
+++ b/ScopeEffectsRenderer.cs
@@ -7,9 +7,8 @@ namespace ScopeHousingMeshSurgery
     /// Renders scope vignette and shadow effects via a CommandBuffer injected at
     /// CameraEvent.AfterEverything on Camera.main, using nonJitteredProjectionMatrix.
     ///
-    /// This is the same technique as ReticleRenderer — both effects are drawn after
-    /// all post-processing (TAA, DLSS, FSR) with explicitly non-jittered matrices,
-    /// eliminating edge flickering from TAA's jittered projection.
+    /// This uses the same command-buffer pattern as ReticleRenderer with explicitly
+    /// non-jittered matrices to keep overlays stable against TAA jitter.
     ///
     /// ── VIGNETTE ───────────────────────────────────────────────────────────────
     /// Screen-space quad centred in view with fixed on-screen size.


### PR DESCRIPTION
### Motivation
- Move the reticle command buffer earlier in the render pipeline by using `CameraEvent.BeforeImageEffects` to align timing with non-jittered projection handling and avoid timing/post-processing issues that could affect overlay stability.

### Description
- Replace `CameraEvent.AfterEverything` with `CameraEvent.BeforeImageEffects` in `ReticleRenderer.AttachToCamera` and the corresponding `RemoveCommandBuffer` call, and update the related log message and header comment; also tighten wording in `ScopeEffectsRenderer`'s header to reflect the shared command-buffer pattern.

### Testing
- Ran the project's automated unit test suite and a runtime smoke test that asserts the command buffer is attached/removed using `BeforeImageEffects` and checks the updated log output, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aff3bc20708328b2afce158c852888)