### PR TITLE
Render unscoped optic lenses as opaque black to eliminate reticle flash

### DIFF
--- a/LensTransparency.cs
+++ b/LensTransparency.cs
@@ -165,7 +165,7 @@ namespace ScopeHousingMeshSurgery
         /// <summary>
         /// Restore all. Called on scope exit.
         /// </summary>
-        public static void RestoreAll()
+        public static void RestoreAll(bool makeLensBlack = false)
         {
             if (_hidden.Count == 0) return;
 
@@ -197,15 +197,18 @@ namespace ScopeHousingMeshSurgery
                             catch { }
                         }
 
+                        if (makeLensBlack)
+                            ForceMaterialBlackOpaque(e.Renderer);
+
                         ScopeHousingMeshSurgeryPlugin.LogVerbose(
-                            $"[LensTransparency] Restored renderer '{e.Renderer.gameObject.name}' forceOff={e.WasForceOff}");
+                            $"[LensTransparency] Restored renderer '{e.Renderer.gameObject.name}' forceOff={e.WasForceOff} black={makeLensBlack}");
                     }
                 }
                 catch { }
             }
 
             ScopeHousingMeshSurgeryPlugin.LogInfo(
-                $"[LensTransparency] Restored {_hidden.Count} lens meshes");
+                $"[LensTransparency] Restored {_hidden.Count} lens meshes (blackOnRestore={makeLensBlack})");
             _hidden.Clear();
         }
 
@@ -296,6 +299,43 @@ namespace ScopeHousingMeshSurgery
 
                     // Force transparent render queue so it can't occlude anything
                     m.renderQueue = 4000;
+                }
+                if (changed)
+                    r.materials = mats;
+            }
+            catch { }
+        }
+
+        /// <summary>
+        /// Forces lens materials to an opaque black look after scope exit.
+        /// This avoids the one-frame reticle/glass flash during unscope transitions.
+        /// </summary>
+        private static void ForceMaterialBlackOpaque(Renderer r)
+        {
+            if (r == null) return;
+            try
+            {
+                var mats = r.materials; // instance per renderer
+                bool changed = false;
+                for (int i = 0; i < mats.Length; i++)
+                {
+                    var m = mats[i];
+                    if (m == null) continue;
+
+                    if (m.HasProperty(_propColor))
+                    {
+                        m.SetColor(_propColor, Color.black);
+                        changed = true;
+                    }
+
+                    if (m.HasProperty(_propSwitchToSight))
+                    {
+                        m.SetFloat(_propSwitchToSight, 0f);
+                        changed = true;
+                    }
+
+                    // Ensure opaque queue so the lens reads as solid black.
+                    m.renderQueue = 2000;
                 }
                 if (changed)
                     r.materials = mats;

--- a/ScopeLifecycle.cs
+++ b/ScopeLifecycle.cs
@@ -797,8 +797,9 @@ namespace ScopeHousingMeshSurgery
             ReticleRenderer.Cleanup();
             ScopeEffectsRenderer.Cleanup();
 
-            // 4. Restore lens
-            LensTransparency.RestoreAll();
+            // 4. Restore lens geometry but force an opaque black lens material while
+            // unscoped to avoid reticle/glass flash on ADS exit.
+            LensTransparency.RestoreAll(makeLensBlack: true);
 
             // 5. Restore camera LOD/culling settings
             CameraSettingsManager.Restore();


### PR DESCRIPTION
### Motivation
- Prevent a one-frame reticle/glass flash when leaving ADS by ensuring restored lens surfaces render as solid black while unscoped. 
- Provide a simple, deterministic fix that works across varied scope shaders where briefly restoring original materials exposes unwanted reticle pixels.

### Description
- Added an optional parameter `makeLensBlack` to `LensTransparency.RestoreAll` so callers can request forcing lens materials to opaque black on restore. 
- Implemented `ForceMaterialBlackOpaque(Renderer)` to set `_Color = black`, `_SwitchToSight = 0` (when present) and move materials to an opaque render queue so the lens reads as solid black. 
- Wired scope-exit cleanup to call `LensTransparency.RestoreAll(makeLensBlack: true)` from `ScopeLifecycle` so unscoped lenses appear black immediately and avoid the flash.

### Testing
- Attempted to run `dotnet build ScopeHousingMeshSurgery.sln` in the environment but the build step failed because `dotnet` is not installed in the container (automated build unavailable).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b008475a488328a0ce41e97f70a9fa)