### PR TITLE
Anchor near profile plane when CutLength changes

### DIFF
--- a/MeshSurgeryManager.cs
+++ b/MeshSurgeryManager.cs
@@ -197,7 +197,7 @@ namespace ScopeHousingMeshSurgery
             public static string BuildKey(Transform scopeRoot, Transform activeMode, MeshFilter mf, Mesh originalAsset, MeshPlaneCutter.KeepSide keepSide, bool isCylinder)
             {
                 var sb = new StringBuilder(512);
-                sb.Append("v2|");
+                sb.Append("v3|");
                 sb.Append(scopeRoot != null ? scopeRoot.name : "scope").Append('|');
                 sb.Append(activeMode != null ? activeMode.name : "mode").Append('|');
                 sb.Append(GetRelativePath(scopeRoot, mf != null ? mf.transform : null)).Append('|');
@@ -213,7 +213,7 @@ namespace ScopeHousingMeshSurgery
                     AppendFloat(sb, ScopeHousingMeshSurgeryPlugin.GetCutStartOffset());
                     AppendFloat(sb, ScopeHousingMeshSurgeryPlugin.GetCutLength());
                     AppendFloat(sb, ScopeHousingMeshSurgeryPlugin.GetNearPreserveDepth());
-                    AppendFloat(sb, ScopeHousingMeshSurgeryPlugin.GetPlane2Position());
+                    AppendFloat(sb, ScopeHousingMeshSurgeryPlugin.GetPlane2PositionNormalized(ScopeHousingMeshSurgeryPlugin.GetCutLength()));
                     AppendFloat(sb, ScopeHousingMeshSurgeryPlugin.GetPlane2Radius());
                     AppendFloat(sb, ScopeHousingMeshSurgeryPlugin.GetPlane3Position());
                     AppendFloat(sb, ScopeHousingMeshSurgeryPlugin.GetPlane3Radius());
@@ -396,7 +396,7 @@ namespace ScopeHousingMeshSurgery
                             float startOff = ScopeHousingMeshSurgeryPlugin.GetCutStartOffset();
                             float cutLen = ScopeHousingMeshSurgeryPlugin.GetCutLength();
                             float preserve = ScopeHousingMeshSurgeryPlugin.GetNearPreserveDepth();
-                            float p2 = ScopeHousingMeshSurgeryPlugin.GetPlane2Position();
+                            float p2 = ScopeHousingMeshSurgeryPlugin.GetPlane2PositionNormalized(cutLen);
                             float r2 = ScopeHousingMeshSurgeryPlugin.GetPlane2Radius();
                             float p3 = ScopeHousingMeshSurgeryPlugin.GetPlane3Position();
                             float r3 = ScopeHousingMeshSurgeryPlugin.GetPlane3Radius();

--- a/PlaneVisualizer.cs
+++ b/PlaneVisualizer.cs
@@ -91,7 +91,7 @@ namespace ScopeHousingMeshSurgery
             {
                 float p1R = ScopeHousingMeshSurgeryPlugin.GetCylinderRadius();
                 float p2R = ScopeHousingMeshSurgeryPlugin.GetPlane2Radius();
-                float p2Pos = ScopeHousingMeshSurgeryPlugin.GetPlane2Position();
+                float p2Pos = ScopeHousingMeshSurgeryPlugin.GetPlane2PositionNormalized(cutLength);
                 float p3R = ScopeHousingMeshSurgeryPlugin.GetPlane3Radius();
                 float p3Pos = ScopeHousingMeshSurgeryPlugin.GetPlane3Position();
                 float p4R = ScopeHousingMeshSurgeryPlugin.GetPlane4Radius();

--- a/ScopeHousingMeshSurgeryPlugin.cs
+++ b/ScopeHousingMeshSurgeryPlugin.cs
@@ -362,7 +362,8 @@ namespace ScopeHousingMeshSurgery
                     new AcceptableValueRange<float>(-0.02f, 0.02f)));
             Plane2Position = Config.Bind("3. Global Mesh Surgery settings", "Plane2Position", 0.1138498f,
                 new ConfigDescription(
-                    "Normalized depth of plane 2 from near (0) to far (1).",
+                    "Plane 2 profile position (0..1) anchored from the near side.\n" +
+                    "Changing CutLength keeps this plane at the same world-space depth from near.",
                     new AcceptableValueRange<float>(0f, 1f)));
             Plane2Radius = Config.Bind("3. Global Mesh Surgery settings", "Plane2Radius", 0.0186338f,
                 new ConfigDescription(
@@ -452,7 +453,7 @@ namespace ScopeHousingMeshSurgery
             CustomMidCylinderPosition = Config.Bind("4. Custom Mesh Surgery settings", "MidCylinderPosition", 0.28f, new ConfigDescription("Custom per-scope mid profile position (0..1).", new AcceptableValueRange<float>(0.01f, 0.99f)));
             CustomFarCylinderRadius = Config.Bind("4. Custom Mesh Surgery settings", "FarCylinderRadius", 0.12f, new ConfigDescription("Custom per-scope far radius in meters.", new AcceptableValueRange<float>(0f, 0.2f)));
             CustomPlane1OffsetMeters = Config.Bind("4. Custom Mesh Surgery settings", "Plane1OffsetMeters", 0f, new ConfigDescription("Custom per-scope plane 1 offset in meters.", new AcceptableValueRange<float>(-0.02f, 0.02f)));
-            CustomPlane2Position = Config.Bind("4. Custom Mesh Surgery settings", "Plane2Position", 0.1138498f, new ConfigDescription("Custom per-scope plane 2 depth (0..1).", new AcceptableValueRange<float>(0f, 1f)));
+            CustomPlane2Position = Config.Bind("4. Custom Mesh Surgery settings", "Plane2Position", 0.1138498f, new ConfigDescription("Custom per-scope plane 2 position (0..1), anchored from near when CutLength changes.", new AcceptableValueRange<float>(0f, 1f)));
             CustomPlane2Radius = Config.Bind("4. Custom Mesh Surgery settings", "Plane2Radius", 0.0186338f, new ConfigDescription("Custom per-scope plane 2 radius in meters.", new AcceptableValueRange<float>(0f, 0.2f)));
             CustomPlane3Position = Config.Bind("4. Custom Mesh Surgery settings", "Plane3Position", 0.55f, new ConfigDescription("Custom per-scope plane 3 depth (0..1).", new AcceptableValueRange<float>(0f, 1f)));
             CustomPlane3Radius = Config.Bind("4. Custom Mesh Surgery settings", "Plane3Radius", 0.2f, new ConfigDescription("Custom per-scope plane 3 radius in meters.", new AcceptableValueRange<float>(0f, 0.2f)));
@@ -547,6 +548,13 @@ namespace ScopeHousingMeshSurgery
         internal static float GetFarCylinderRadius() => ActiveScopeOverride != null ? ActiveScopeOverride.FarCylinderRadius : FarCylinderRadius.Value;
         internal static float GetPlane1OffsetMeters() => ActiveScopeOverride != null ? ActiveScopeOverride.Plane1OffsetMeters : Plane1OffsetMeters.Value;
         internal static float GetPlane2Position() => ActiveScopeOverride != null ? ActiveScopeOverride.Plane2Position : Plane2Position.Value;
+        internal static float GetPlane2PositionNormalized(float cutLength)
+        {
+            const float legacyReferenceCutLength = 0.755493f;
+            float p2LegacyNormalized = Mathf.Clamp01(GetPlane2Position());
+            float anchoredDepth = p2LegacyNormalized * legacyReferenceCutLength;
+            return cutLength > 1e-5f ? Mathf.Clamp01(anchoredDepth / cutLength) : 0f;
+        }
         internal static float GetPlane2Radius() => ActiveScopeOverride != null ? ActiveScopeOverride.Plane2Radius : Plane2Radius.Value;
         internal static float GetPlane3Position() => ActiveScopeOverride != null ? ActiveScopeOverride.Plane3Position : Plane3Position.Value;
         internal static float GetPlane3Radius() => ActiveScopeOverride != null ? ActiveScopeOverride.Plane3Radius : Plane3Radius.Value;


### PR DESCRIPTION
### Motivation
- Changing `CutLength` moved the internal near-side profile plane (plane 2) in world space, which is undesirable because the plane closest to the camera should remain anchored. 
- Preserve existing configuration semantics while making plane 2 stable when the cut depth is adjusted. 

### Description
- Added `GetPlane2PositionNormalized(float cutLength)` in `ScopeHousingMeshSurgeryPlugin.cs` which converts the existing `Plane2Position` config into a normalized position anchored to the near side using a legacy reference cut length. 
- Updated the mesh-cut pipeline in `MeshSurgeryManager.cs` to use the anchored normalized plane-2 value for `CutMeshFrustum` and included the normalized value in the mesh-cut cache key; bumped cache key version from `v2` to `v3`. 
- Updated visualization in `PlaneVisualizer.cs` to use the same anchored normalized plane-2 position so the cut-volume preview matches the actual cutting behavior. 
- Clarified config descriptions for global and per-scope `Plane2Position` to indicate the anchored behavior and preserved per-scope defaults. 

### Testing
- Ran `git diff --check` and the working tree changes contain no whitespace errors. (passed) 
- Attempted `dotnet build ScopeHousingMeshSurgery.csproj -v minimal` to validate compilation but `dotnet` is not available in this environment, so a full build could not be executed here. (not run)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0745b3cd083288217f769200e642b)