### PR TITLE
Guard scope lifecycle against empty ScopeAimTransforms

### DIFF
--- a/Patches/ScopeLifecycle.cs
+++ b/Patches/ScopeLifecycle.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Reflection;
 using System.Collections.Generic;
+using System.Collections;
 using EFT;
 using EFT.Animations;
 using EFT.CameraControl;
@@ -31,12 +32,14 @@ namespace ScopeHousingMeshSurgery
         private static PropertyInfo _isAimingProp;
         private static PropertyInfo _currentScopeProp;
         private static PropertyInfo _isOpticProp;
+        private static PropertyInfo _scopeAimTransformsProp;
         private static bool _reflectionReady;
 
         // Fast delegates (avoid PropertyInfo.GetValue overhead per frame)
         private static Func<ProceduralWeaponAnimation, bool> _getIsAiming;
         private static Func<ProceduralWeaponAnimation, object> _getCurrentScope;
         private static Func<object, bool> _getIsOptic;
+        private static Func<ProceduralWeaponAnimation, object> _getScopeAimTransforms;
 
         // State
         private static bool _isScoped;
@@ -103,6 +106,7 @@ namespace ScopeHousingMeshSurgery
                 var pwaType = typeof(ProceduralWeaponAnimation);
                 _isAimingProp = AccessTools.Property(pwaType, "IsAiming");
                 _currentScopeProp = AccessTools.Property(pwaType, "CurrentScope");
+                _scopeAimTransformsProp = AccessTools.Property(pwaType, "ScopeAimTransforms");
 
                 if (_currentScopeProp != null)
                 {
@@ -148,6 +152,19 @@ namespace ScopeHousingMeshSurgery
                     catch
                     {
                         _getIsOptic = scope => (bool)_isOpticProp.GetValue(scope);
+                    }
+
+                    if (_scopeAimTransformsProp != null)
+                    {
+                        try
+                        {
+                            var getter = _scopeAimTransformsProp.GetGetMethod(true);
+                            _getScopeAimTransforms = pwa => getter.Invoke(pwa, null);
+                        }
+                        catch
+                        {
+                            _getScopeAimTransforms = pwa => _scopeAimTransformsProp.GetValue(pwa);
+                        }
                     }
                 }
 
@@ -262,6 +279,19 @@ namespace ScopeHousingMeshSurgery
 
                 bool isAiming = _getIsAiming(pwa);
                 if (!isAiming) { reason = "not aiming"; goto evaluate; }
+
+                int scopeCount;
+                if (!TryGetScopeAimTransformCount(pwa, out scopeCount))
+                {
+                    reason = "ScopeAimTransforms unavailable";
+                    goto evaluate;
+                }
+
+                if (scopeCount < 1)
+                {
+                    reason = "ScopeAimTransforms empty";
+                    goto evaluate;
+                }
 
                 object currentScope = _getCurrentScope(pwa);
                 if (currentScope == null) { reason = "no CurrentScope"; goto evaluate; }
@@ -1016,6 +1046,36 @@ namespace ScopeHousingMeshSurgery
                 return gw != null ? gw.MainPlayer : null;
             }
             catch { return null; }
+        }
+
+        private static bool TryGetScopeAimTransformCount(ProceduralWeaponAnimation pwa, out int count)
+        {
+            count = 0;
+            if (pwa == null) return false;
+            if (_getScopeAimTransforms == null) return false;
+
+            try
+            {
+                object scopeAimTransforms = _getScopeAimTransforms(pwa);
+                if (scopeAimTransforms == null) return false;
+
+                if (scopeAimTransforms is IList list)
+                {
+                    count = list.Count;
+                    return true;
+                }
+
+                var countProp = AccessTools.Property(scopeAimTransforms.GetType(), "Count");
+                if (countProp == null) return false;
+                object rawCount = countProp.GetValue(scopeAimTransforms);
+                if (!(rawCount is int value)) return false;
+                count = value;
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
### Motivation
- Prevent crashes or incorrect scope-state detection when `ProceduralWeaponAnimation.CurrentScope` is accessed while the underlying `ScopeAimTransforms` list is not yet populated during weapon/scope transitions.

### Description
- Add reflected access and a cached delegate for `ProceduralWeaponAnimation.ScopeAimTransforms` via `_scopeAimTransformsProp` / `_getScopeAimTransforms`.
- In `CheckAndUpdate`, query `ScopeAimTransforms.Count` first using a new `TryGetScopeAimTransformCount(...)` helper and early-return if the collection is unavailable or empty before reading `CurrentScope`.
- Implement `TryGetScopeAimTransformCount` to safely obtain the count from an `IList` or a reflected `Count` property and to fail gracefully on exceptions.
- Import `System.Collections` and wire the new reflection field and helper into the existing reflection initialization path.

### Testing
- Ran `dotnet build -c Release` to validate the change but the command failed in this environment because `dotnet` is not installed, so no build artifacts were produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3307b7cf88328bd8486025dcb7925)