### PR TITLE
Refactor: rename plugin/namespace to PiPDisabler and centralize config overrides

### DIFF
--- a/Patches/CameraSettingsManager.cs
+++ b/Patches/CameraSettingsManager.cs
@@ -4,7 +4,7 @@ using EFT.CameraControl;
 using HarmonyLib;
 using UnityEngine;
 
-namespace ScopeHousingMeshSurgery
+namespace PiPDisabler
 {
     /// <summary>
     /// Swaps main camera LOD bias and culling settings with scope-appropriate values during ADS.
@@ -51,7 +51,7 @@ namespace ScopeHousingMeshSurgery
         {
             if (os == null) return;
 
-            var cam = ScopeHousingMeshSurgeryPlugin.GetMainCamera();
+            var cam = PiPDisablerPlugin.GetMainCamera();
             if (cam == null) return;
 
             // Save originals (only on first apply, not re-apply from mode switch)
@@ -65,7 +65,7 @@ namespace ScopeHousingMeshSurgery
                 _savedMaxLodLevel = QualitySettings.maximumLODLevel;
                 _applied = true;
 
-                ScopeHousingMeshSurgeryPlugin.LogVerbose(
+                PiPDisablerPlugin.LogVerbose(
                     $"[CameraSettings] Saved: lodBias={_savedLodBias:F2} farClip={_savedFarClip:F0} " +
                     $"maxLOD={_savedMaxLodLevel}");
             }
@@ -76,7 +76,7 @@ namespace ScopeHousingMeshSurgery
 
             if (TryGetScopeCameraData(os, out scopeFov, out scopeFarClip))
             {
-                ScopeHousingMeshSurgeryPlugin.LogVerbose(
+                PiPDisablerPlugin.LogVerbose(
                     $"[CameraSettings] ScopeCameraData: FOV={scopeFov:F2} FarClip={scopeFarClip:F0}");
             }
 
@@ -88,8 +88,8 @@ namespace ScopeHousingMeshSurgery
             // === Apply LOD bias ===
             // Increase LOD bias proportionally to magnification.
             // At 4x zoom, objects at distance appear 4x larger → use 4x finer LODs.
-            float manualLodBias = ScopeHousingMeshSurgeryPlugin.ManualLodBias != null
-                ? ScopeHousingMeshSurgeryPlugin.ManualLodBias.Value
+            float manualLodBias = PiPDisablerPlugin.ManualLodBias != null
+                ? PiPDisablerPlugin.ManualLodBias.Value
                 : 0f;
             float newLodBias = manualLodBias > 0f
                 ? manualLodBias
@@ -97,8 +97,8 @@ namespace ScopeHousingMeshSurgery
             QualitySettings.lodBias = newLodBias;
 
             // Force highest LOD by default unless overridden by manual max LOD level.
-            int manualMaxLod = ScopeHousingMeshSurgeryPlugin.ManualMaximumLodLevel != null
-                ? ScopeHousingMeshSurgeryPlugin.ManualMaximumLodLevel.Value
+            int manualMaxLod = PiPDisablerPlugin.ManualMaximumLodLevel != null
+                ? PiPDisablerPlugin.ManualMaximumLodLevel.Value
                 : -1;
             int appliedMaxLod = manualMaxLod >= 0 ? manualMaxLod : 0;
             QualitySettings.maximumLODLevel = appliedMaxLod;
@@ -111,8 +111,8 @@ namespace ScopeHousingMeshSurgery
             // Increase cull distances proportionally so objects stay visible when zoomed
             if (_savedCullDistances != null)
             {
-                float manualCullMultiplier = ScopeHousingMeshSurgeryPlugin.ManualCullingMultiplier != null
-                    ? ScopeHousingMeshSurgeryPlugin.ManualCullingMultiplier.Value
+                float manualCullMultiplier = PiPDisablerPlugin.ManualCullingMultiplier != null
+                    ? PiPDisablerPlugin.ManualCullingMultiplier.Value
                     : 0f;
                 float cullingMultiplier = manualCullMultiplier > 0f
                     ? manualCullMultiplier
@@ -127,7 +127,7 @@ namespace ScopeHousingMeshSurgery
                 cam.layerCullDistances = newCull;
             }
 
-            ScopeHousingMeshSurgeryPlugin.LogInfo(
+            PiPDisablerPlugin.LogInfo(
                 $"[CameraSettings] Applied: lodBias {_savedLodBias:F2}→{newLodBias:F2} " +
                 $"(mag={magnification:F1}x) farClip={cam.farClipPlane:F0} maxLOD={appliedMaxLod}");
         }
@@ -142,14 +142,14 @@ namespace ScopeHousingMeshSurgery
             QualitySettings.lodBias = _savedLodBias;
             QualitySettings.maximumLODLevel = _savedMaxLodLevel;
 
-            var cam = ScopeHousingMeshSurgeryPlugin.GetMainCamera();            if (cam != null)
+            var cam = PiPDisablerPlugin.GetMainCamera();            if (cam != null)
             {
                 cam.farClipPlane = _savedFarClip;
                 if (_savedCullDistances != null)
                     cam.layerCullDistances = _savedCullDistances;
             }
 
-            ScopeHousingMeshSurgeryPlugin.LogInfo(
+            PiPDisablerPlugin.LogInfo(
                 $"[CameraSettings] Restored: lodBias={_savedLodBias:F2} " +
                 $"farClip={_savedFarClip:F0} maxLOD={_savedMaxLodLevel}");
 
@@ -260,7 +260,7 @@ namespace ScopeHousingMeshSurgery
                         if (f1.FieldType != typeof(float)) continue;
 
                         CacheFields(type);
-                        ScopeHousingMeshSurgeryPlugin.LogInfo(
+                        PiPDisablerPlugin.LogInfo(
                             $"[CameraSettings] Found ScopeCameraData: {type.FullName}");
                         return;
                     }

--- a/Patches/FovController.cs
+++ b/Patches/FovController.cs
@@ -5,7 +5,7 @@ using EFT.CameraControl;
 using HarmonyLib;
 using UnityEngine;
 
-namespace ScopeHousingMeshSurgery
+namespace PiPDisabler
 {
     /// <summary>
     /// Computes the zoomed FOV for the main camera from template zoom multipliers.
@@ -75,8 +75,8 @@ namespace ScopeHousingMeshSurgery
             _ = baseFov;
             _ = pwa;
 
-            if (!ScopeHousingMeshSurgeryPlugin.AutoFovFromScope.Value)
-                return ScopeHousingMeshSurgeryPlugin.ScopedFov.Value;
+            if (!PiPDisablerPlugin.AutoFovFromScope.Value)
+                return PiPDisablerPlugin.ScopedFov.Value;
 
             float magnification = GetEffectiveMagnification();
             if (magnification > 0.1f)
@@ -88,7 +88,7 @@ namespace ScopeHousingMeshSurgery
                 if (Mathf.Abs(magnification - _lastLoggedMag) > 0.01f)
                 {
                     _lastLoggedMag = magnification;
-                    ScopeHousingMeshSurgeryPlugin.LogInfo(
+                    PiPDisablerPlugin.LogInfo(
                         $"[FovController] mag={magnification:F2}x → mainFov={resultFov:F1}° " +
                         $"(baseline={ZoomBaselineFov:F0}°) [{source}]");
                 }
@@ -96,7 +96,7 @@ namespace ScopeHousingMeshSurgery
                 return resultFov;
             }
 
-            return ScopeHousingMeshSurgeryPlugin.ScopedFov.Value;
+            return PiPDisablerPlugin.ScopedFov.Value;
         }
 
         /// <summary>
@@ -138,7 +138,7 @@ namespace ScopeHousingMeshSurgery
 
             // 3. Config default
             _lastLoggedSource = "DEFAULT";
-            return ScopeHousingMeshSurgeryPlugin.DefaultZoom.Value;
+            return PiPDisablerPlugin.DefaultZoom.Value;
         }
 
         /// <summary>
@@ -229,7 +229,7 @@ namespace ScopeHousingMeshSurgery
                     if (minZoom > 0.1f && maxZoom > 0.1f && maxZoom > minZoom)
                     {
                         float zoom = Mathf.Lerp(minZoom, maxZoom, zoomT);
-                        ScopeHousingMeshSurgeryPlugin.LogVerbose(
+                        PiPDisablerPlugin.LogVerbose(
                             $"[FovController] Variable zoom: min={minZoom:F2}x max={maxZoom:F2}x " +
                             $"t={zoomT:F3} → {zoom:F2}x");
                         return zoom;
@@ -240,14 +240,14 @@ namespace ScopeHousingMeshSurgery
                 float currentZoom = (float)_getCurrentZoom.Invoke(sightComponent, null);
                 if (currentZoom > 0.1f)
                 {
-                    ScopeHousingMeshSurgeryPlugin.LogVerbose(
+                    PiPDisablerPlugin.LogVerbose(
                         $"[FovController] Template zoom: {currentZoom:F2}x (stepped)");
                     return currentZoom;
                 }
             }
             catch (Exception ex)
             {
-                ScopeHousingMeshSurgeryPlugin.LogVerbose(
+                PiPDisablerPlugin.LogVerbose(
                     $"[FovController] GetTemplateZoom exception: {ex.Message}");
             }
 
@@ -466,7 +466,7 @@ namespace ScopeHousingMeshSurgery
             }
             catch (Exception ex)
             {
-                ScopeHousingMeshSurgeryPlugin.LogVerbose(
+                PiPDisablerPlugin.LogVerbose(
                     $"[FovController] FindSightComponent exception: {ex.Message}");
             }
 
@@ -500,7 +500,7 @@ namespace ScopeHousingMeshSurgery
                         {
                             _smvcType = t;
                             _sightModProp = prop;
-                            ScopeHousingMeshSurgeryPlugin.LogInfo(
+                            PiPDisablerPlugin.LogInfo(
                                 $"[FovController] Found SightModVisualControllers: {t.FullName}, " +
                                 $"SightMod={prop.Name} ({prop.PropertyType.Name})");
                             return;
@@ -512,7 +512,7 @@ namespace ScopeHousingMeshSurgery
 
             // Strategy 2: Scan assemblies for MonoBehaviour with a property whose
             // return type has GetCurrentOpticZoom method
-            ScopeHousingMeshSurgeryPlugin.LogVerbose(
+            PiPDisablerPlugin.LogVerbose(
                 "[FovController] SightModVisualControllers name lookup failed, scanning assemblies...");
 
             foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
@@ -528,7 +528,7 @@ namespace ScopeHousingMeshSurgery
                         {
                             _smvcType = type;
                             _sightModProp = prop;
-                            ScopeHousingMeshSurgeryPlugin.LogInfo(
+                            PiPDisablerPlugin.LogInfo(
                                 $"[FovController] Discovered SightModVisualControllers via scan: " +
                                 $"{type.FullName}, SightMod={prop.Name} ({prop.PropertyType.Name})");
                             return;
@@ -538,7 +538,7 @@ namespace ScopeHousingMeshSurgery
                 catch { }
             }
 
-            ScopeHousingMeshSurgeryPlugin.LogWarn(
+            PiPDisablerPlugin.LogWarn(
                 "[FovController] SightModVisualControllers NOT found — template zoom unavailable");
         }
 
@@ -622,7 +622,7 @@ namespace ScopeHousingMeshSurgery
                                   ?? templateType.GetField("Name", anyFlags);
             }
 
-            ScopeHousingMeshSurgeryPlugin.LogInfo(
+            PiPDisablerPlugin.LogInfo(
                 $"[FovController] SightComponent members: " +
                 $"GetCurrentOpticZoom={_getCurrentZoom != null}, " +
                 $"GetMinOpticZoom={_getMinZoom != null}, " +
@@ -725,7 +725,7 @@ namespace ScopeHousingMeshSurgery
                     float fov = (float)_scopeCamDataFovField.GetValue(scd);
                     if (fov > 0.1f)
                     {
-                        ScopeHousingMeshSurgeryPlugin.LogVerbose(
+                        PiPDisablerPlugin.LogVerbose(
                             $"[FovController] ScopeCameraData fallback: FOV={fov:F2}");
                         return fov;
                     }
@@ -761,7 +761,7 @@ namespace ScopeHousingMeshSurgery
 
                     if (IsOnSameModeAs(mb.transform, os.transform))
                     {
-                        ScopeHousingMeshSurgeryPlugin.LogVerbose(
+                        PiPDisablerPlugin.LogVerbose(
                             $"[FovController] BruteForce fallback: {mb.gameObject.name} FOV={fov:F2}");
                         if (_scopeCamDataType == null)
                         {
@@ -774,7 +774,7 @@ namespace ScopeHousingMeshSurgery
             }
             catch (Exception ex)
             {
-                ScopeHousingMeshSurgeryPlugin.LogVerbose(
+                PiPDisablerPlugin.LogVerbose(
                     $"[FovController] BruteForce error: {ex.Message}");
             }
             return 0f;
@@ -804,7 +804,7 @@ namespace ScopeHousingMeshSurgery
                         {
                             _scopeCamDataType = t;
                             _scopeCamDataFovField = f;
-                            ScopeHousingMeshSurgeryPlugin.LogInfo(
+                            PiPDisablerPlugin.LogInfo(
                                 $"[FovController] Found ScopeCameraData: {t.FullName}");
                             return;
                         }
@@ -829,7 +829,7 @@ namespace ScopeHousingMeshSurgery
 
                         _scopeCamDataType = type;
                         _scopeCamDataFovField = fovF;
-                        ScopeHousingMeshSurgeryPlugin.LogInfo(
+                        PiPDisablerPlugin.LogInfo(
                             $"[FovController] Discovered ScopeCameraData via scan: {type.FullName}");
                         return;
                     }
@@ -837,7 +837,7 @@ namespace ScopeHousingMeshSurgery
                 catch { }
             }
 
-            ScopeHousingMeshSurgeryPlugin.LogInfo(
+            PiPDisablerPlugin.LogInfo(
                 "[FovController] ScopeCameraData type NOT found — fallback unavailable");
         }
 

--- a/Patches/LensTransparency.cs
+++ b/Patches/LensTransparency.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using EFT.CameraControl;
 using UnityEngine;
 
-namespace ScopeHousingMeshSurgery
+namespace PiPDisabler
 {
     /// <summary>
     /// Makes scope lens surfaces invisible by REPLACING THEIR MESH with an empty mesh
@@ -130,7 +130,7 @@ namespace ScopeHousingMeshSurgery
                 }
             }
             _blackenedRenderers.Clear();
-            ScopeHousingMeshSurgeryPlugin.LogInfo(
+            PiPDisablerPlugin.LogInfo(
                 "[LensTransparency] Restored original materials before scope entry");
         }
 
@@ -143,7 +143,7 @@ namespace ScopeHousingMeshSurgery
         {
             RestoreBlackLensMaterials(); // also clears _blackenedRenderers
             _trulyOriginalMaterials.Clear();
-            ScopeHousingMeshSurgeryPlugin.LogInfo(
+            PiPDisablerPlugin.LogInfo(
                 "[LensTransparency] FullRestoreAll: caches cleared");
         }
 
@@ -156,8 +156,8 @@ namespace ScopeHousingMeshSurgery
         {
             if (os == null) return;
 
-            bool shouldHide = ScopeHousingMeshSurgeryPlugin.MakeLensesTransparent.Value
-                              || ScopeHousingMeshSurgeryPlugin.DisablePiP.Value;
+            bool shouldHide = PiPDisablerPlugin.MakeLensesTransparent.Value
+                              || PiPDisablerPlugin.DisablePiP.Value;
             if (!shouldHide) return;
 
             Transform searchRoot = FindScopeSearchRoot(os.transform);
@@ -191,7 +191,7 @@ namespace ScopeHousingMeshSurgery
             }
             catch { }
 
-            ScopeHousingMeshSurgeryPlugin.LogInfo(
+            PiPDisablerPlugin.LogInfo(
                 $"[LensTransparency] Destroyed geometry on {killed} lens surfaces (searchRoot='{searchRoot.name}')");
         }
 
@@ -201,8 +201,8 @@ namespace ScopeHousingMeshSurgery
         public static void HideLens(Renderer lens)
         {
             if (lens == null) return;
-            bool shouldHide = ScopeHousingMeshSurgeryPlugin.MakeLensesTransparent.Value
-                              || ScopeHousingMeshSurgeryPlugin.DisablePiP.Value;
+            bool shouldHide = PiPDisablerPlugin.MakeLensesTransparent.Value
+                              || PiPDisablerPlugin.DisablePiP.Value;
             if (!shouldHide) return;
             KillMesh(lens);
         }
@@ -234,13 +234,13 @@ namespace ScopeHousingMeshSurgery
                 if (e.Skinned != null && e.Skinned.sharedMesh != emptyMesh)
                 {
                     e.Skinned.sharedMesh = emptyMesh;
-                    ScopeHousingMeshSurgeryPlugin.LogVerbose(
+                    PiPDisablerPlugin.LogVerbose(
                         $"[LensTransparency] Re-emptied skinned mesh on '{e.Skinned.gameObject.name}'");
                 }
                 else if (e.Filter != null && e.Filter.sharedMesh != emptyMesh)
                 {
                     e.Filter.sharedMesh = emptyMesh;
-                    ScopeHousingMeshSurgeryPlugin.LogVerbose(
+                    PiPDisablerPlugin.LogVerbose(
                         $"[LensTransparency] Re-emptied mesh on '{e.Filter.gameObject.name}'");
                 }
                 if (e.Renderer != null)
@@ -267,8 +267,8 @@ namespace ScopeHousingMeshSurgery
         {
             if (_hidden.Count == 0) return;
 
-            bool blackLens = ScopeHousingMeshSurgeryPlugin.BlackLensWhenUnscoped != null
-                             && ScopeHousingMeshSurgeryPlugin.BlackLensWhenUnscoped.Value;
+            bool blackLens = PiPDisablerPlugin.BlackLensWhenUnscoped != null
+                             && PiPDisablerPlugin.BlackLensWhenUnscoped.Value;
 
             for (int i = 0; i < _hidden.Count; i++)
             {
@@ -279,13 +279,13 @@ namespace ScopeHousingMeshSurgery
                     if (e.Skinned != null && e.OriginalMesh != null)
                     {
                         e.Skinned.sharedMesh = e.OriginalMesh;
-                        ScopeHousingMeshSurgeryPlugin.LogVerbose(
+                        PiPDisablerPlugin.LogVerbose(
                             $"[LensTransparency] Restored skinned mesh on '{e.Skinned.gameObject.name}' → {e.OriginalMesh.vertexCount} verts");
                     }
                     else if (e.Filter != null && e.OriginalMesh != null)
                     {
                         e.Filter.sharedMesh = e.OriginalMesh;
-                        ScopeHousingMeshSurgeryPlugin.LogVerbose(
+                        PiPDisablerPlugin.LogVerbose(
                             $"[LensTransparency] Restored mesh on '{e.Filter.gameObject.name}' → {e.OriginalMesh.vertexCount} verts");
                     }
 
@@ -298,7 +298,7 @@ namespace ScopeHousingMeshSurgery
                         {
                             // Apply solid black material — no PiP texture, no reticle flash.
                             ApplyBlackMaterial(e.Renderer);
-                            ScopeHousingMeshSurgeryPlugin.LogVerbose(
+                            PiPDisablerPlugin.LogVerbose(
                                 $"[LensTransparency] Applied black lens to '{e.Renderer.gameObject.name}'");
                         }
                         else
@@ -309,7 +309,7 @@ namespace ScopeHousingMeshSurgery
                                 try { e.Renderer.sharedMaterials = e.OriginalMaterials; }
                                 catch { }
                             }
-                            ScopeHousingMeshSurgeryPlugin.LogVerbose(
+                            PiPDisablerPlugin.LogVerbose(
                                 $"[LensTransparency] Restored renderer '{e.Renderer.gameObject.name}' forceOff={e.WasForceOff}");
                         }
                     }
@@ -317,7 +317,7 @@ namespace ScopeHousingMeshSurgery
                 catch { }
             }
 
-            ScopeHousingMeshSurgeryPlugin.LogInfo(
+            PiPDisablerPlugin.LogInfo(
                 $"[LensTransparency] Restored {_hidden.Count} lens meshes" +
                 (blackLens ? " (black lens applied)" : ""));
             _hidden.Clear();
@@ -384,7 +384,7 @@ namespace ScopeHousingMeshSurgery
             // reference — even with empty mesh, the material state gets cleaned up.
             ForceMaterialTransparent(r);
 
-            ScopeHousingMeshSurgeryPlugin.LogInfo(
+            PiPDisablerPlugin.LogInfo(
                 $"[LensTransparency] MESH DESTROYED: '{r.gameObject.name}' " +
                 $"(had {(origMesh != null ? origMesh.vertexCount.ToString() : "?")} verts → 0) " +
                 $"MeshFilter={(mf != null ? "yes" : "NO")}, Skinned={(smr != null ? "yes" : "NO")}");
@@ -622,26 +622,26 @@ namespace ScopeHousingMeshSurgery
 
                 if (ContainsCI(meshName, "LOD1"))
                 {
-                    ScopeHousingMeshSurgeryPlugin.LogInfo(
+                    PiPDisablerPlugin.LogInfo(
                         $"[LensTransparency] HousingMask -skip LOD1 mesh: go='{goName}' mesh='{meshName}'");
                     continue;
                 }
 
                 if (LooksLikeLensName(meshName) || LooksLikeLensName(goName))
                 {
-                    ScopeHousingMeshSurgeryPlugin.LogInfo(
+                    PiPDisablerPlugin.LogInfo(
                         $"[LensTransparency] HousingMask -skip lens-like mesh: go='{goName}' mesh='{meshName}'");
                     continue;
                 }
 
                 result.Add(r);
-                ScopeHousingMeshSurgeryPlugin.LogInfo(
+                PiPDisablerPlugin.LogInfo(
                     $"[LensTransparency] HousingMask +renderer: go='{r.gameObject.name}'" +
                     $" mesh='{mesh.name}' verts={mesh.vertexCount}" +
                     $" shader='{(r.sharedMaterial?.shader?.name ?? "null")}'");
             }
 
-            ScopeHousingMeshSurgeryPlugin.LogInfo(
+            PiPDisablerPlugin.LogInfo(
                 $"[LensTransparency] CollectHousingRenderers: {result.Count} renderer(s)" +
                 $" (searchRoot='{searchRoot?.name ?? "null"}' from '{os.name}')");
 
@@ -686,7 +686,7 @@ namespace ScopeHousingMeshSurgery
             Transform weaponRoot = FindWeaponRoot(os.transform);
             if (weaponRoot == null)
             {
-                ScopeHousingMeshSurgeryPlugin.LogInfo(
+                PiPDisablerPlugin.LogInfo(
                     "[LensTransparency] CollectWeaponRenderers: no 'weapon' root found");
                 return result;
             }
@@ -716,12 +716,12 @@ namespace ScopeHousingMeshSurgery
                 if (LooksLikeLensName(meshName) || LooksLikeLensName(goName)) continue;
 
                 result.Add(r);
-                ScopeHousingMeshSurgeryPlugin.LogInfo(
+                PiPDisablerPlugin.LogInfo(
                     $"[LensTransparency] WeaponMask +renderer: go='{goName}'" +
                     $" mesh='{meshName}' verts={mesh.vertexCount}");
             }
 
-            ScopeHousingMeshSurgeryPlugin.LogInfo(
+            PiPDisablerPlugin.LogInfo(
                 $"[LensTransparency] CollectWeaponRenderers: {result.Count} renderer(s)" +
                 $" (weaponRoot='{weaponRoot.name}')");
 
@@ -733,11 +733,11 @@ namespace ScopeHousingMeshSurgery
         private static bool _dumpedOnce;
         private static void DumpHierarchy(Transform root)
         {
-            if (_dumpedOnce && !ScopeHousingMeshSurgeryPlugin.VerboseLogging.Value)
+            if (_dumpedOnce && !PiPDisablerPlugin.VerboseLogging.Value)
                 return;
             _dumpedOnce = true;
 
-            ScopeHousingMeshSurgeryPlugin.LogInfo(
+            PiPDisablerPlugin.LogInfo(
                 $"[LensTransparency] === SCOPE HIERARCHY DUMP: '{root.name}' ===");
 
             var allRenderers = root.GetComponentsInChildren<Renderer>(true);
@@ -775,14 +775,14 @@ namespace ScopeHousingMeshSurgery
                 bool isLens = IsLensSurface(r);
                 string path = GetRelativePath(r.transform, root);
 
-                ScopeHousingMeshSurgeryPlugin.LogInfo(
+                PiPDisablerPlugin.LogInfo(
                     $"[LensTransparency]   {(isLens ? "★LENS★" : "      ")} " +
                     $"'{path}' mesh='{meshName}' verts={verts} enabled={r.enabled} " +
                     $"active={r.gameObject.activeSelf} layer={r.gameObject.layer} " +
                     $"mats=[{matInfo}]");
             }
 
-            ScopeHousingMeshSurgeryPlugin.LogInfo(
+            PiPDisablerPlugin.LogInfo(
                 $"[LensTransparency] === END DUMP ({allRenderers.Length} renderers) ===");
         }
 

--- a/Patches/MeshPlaneCutter.cs
+++ b/Patches/MeshPlaneCutter.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Rendering;
 
-namespace ScopeHousingMeshSurgery
+namespace PiPDisabler
 {
     public static class MeshPlaneCutter
     {
@@ -291,12 +291,12 @@ namespace ScopeHousingMeshSurgery
             // Log the radius profile so we can verify mid-radius is being applied
             if (midRadius > 0f)
             {
-                ScopeHousingMeshSurgeryPlugin.LogVerbose(
+                PiPDisablerPlugin.LogVerbose(
                     $"[MeshCutter] Radius profile for '{mesh.name}': " +
                     $"localNear={localNearR:F5} localMid={localMidR:F5}@{localMidPos:F2} localFar={localFarR:F5} " +
                     $"avgScale={avgScale:F4} localLen={localLen:F4}");
                 // Sample the profile at 5 points for visual verification
-                ScopeHousingMeshSurgeryPlugin.LogVerbose(
+                PiPDisablerPlugin.LogVerbose(
                     $"[MeshCutter] Profile samples: " +
                     $"t=0.0→r={RadiusAtT4(0f, localNearR, localMidR, localMidPos, localP3R, localP3Pos, localFarR, localP4Pos):F5} " +
                     $"t=0.25→r={RadiusAtT4(0.25f, localNearR, localMidR, localMidPos, localP3R, localP3Pos, localFarR, localP4Pos):F5} " +

--- a/Patches/MeshSurgeryManager.cs
+++ b/Patches/MeshSurgeryManager.cs
@@ -7,7 +7,7 @@ using System.Text;
 using EFT.CameraControl;
 using UnityEngine;
 
-namespace ScopeHousingMeshSurgery
+namespace PiPDisabler
 {
     public static class MeshSurgeryManager
     {
@@ -33,7 +33,7 @@ namespace ScopeHousingMeshSurgery
 
         public static void ClearPersistentCache()
         {
-            string cacheDir = ScopeHousingMeshSurgeryPlugin.GetMeshCutCacheDirectory();
+            string cacheDir = PiPDisablerPlugin.GetMeshCutCacheDirectory();
             if (!Directory.Exists(cacheDir)) return;
 
             try
@@ -45,12 +45,12 @@ namespace ScopeHousingMeshSurgery
                     removed++;
                 }
 
-                ScopeHousingMeshSurgeryPlugin.LogInfo(
+                PiPDisablerPlugin.LogInfo(
                     $"[MeshSurgery] Cleared persistent mesh cache: removed {removed} file(s).");
             }
             catch (Exception ex)
             {
-                ScopeHousingMeshSurgeryPlugin.LogWarn(
+                PiPDisablerPlugin.LogWarn(
                     $"[MeshSurgery] Failed to clear persistent cache: {ex.Message}");
             }
         }
@@ -122,7 +122,7 @@ namespace ScopeHousingMeshSurgery
                 }
                 catch (Exception ex)
                 {
-                    ScopeHousingMeshSurgeryPlugin.LogVerbose($"[MeshSurgery] Cache load failed '{path}': {ex.Message}");
+                    PiPDisablerPlugin.LogVerbose($"[MeshSurgery] Cache load failed '{path}': {ex.Message}");
                     return false;
                 }
             }
@@ -189,7 +189,7 @@ namespace ScopeHousingMeshSurgery
                 }
                 catch (Exception ex)
                 {
-                    ScopeHousingMeshSurgeryPlugin.LogVerbose($"[MeshSurgery] Cache save failed '{path}': {ex.Message}");
+                    PiPDisablerPlugin.LogVerbose($"[MeshSurgery] Cache save failed '{path}': {ex.Message}");
                     try { if (File.Exists(tmpPath)) File.Delete(tmpPath); } catch { }
                 }
             }
@@ -209,21 +209,21 @@ namespace ScopeHousingMeshSurgery
 
                 if (isCylinder)
                 {
-                    AppendFloat(sb, ScopeHousingMeshSurgeryPlugin.GetCylinderRadius());
-                    AppendFloat(sb, ScopeHousingMeshSurgeryPlugin.GetCutStartOffset());
-                    AppendFloat(sb, ScopeHousingMeshSurgeryPlugin.GetCutLength());
-                    AppendFloat(sb, ScopeHousingMeshSurgeryPlugin.GetNearPreserveDepth());
-                    AppendFloat(sb, ScopeHousingMeshSurgeryPlugin.GetPlane2PositionNormalized(ScopeHousingMeshSurgeryPlugin.GetCutLength()));
-                    AppendFloat(sb, ScopeHousingMeshSurgeryPlugin.GetPlane2Radius());
-                    AppendFloat(sb, ScopeHousingMeshSurgeryPlugin.GetPlane3Position());
-                    AppendFloat(sb, ScopeHousingMeshSurgeryPlugin.GetPlane3Radius());
-                    AppendFloat(sb, ScopeHousingMeshSurgeryPlugin.GetPlane4Position());
-                    AppendFloat(sb, ScopeHousingMeshSurgeryPlugin.GetPlane4Radius());
-                    AppendFloat(sb, ScopeHousingMeshSurgeryPlugin.GetPlane1OffsetMeters());
+                    AppendFloat(sb, PiPDisablerPlugin.GetCylinderRadius());
+                    AppendFloat(sb, PiPDisablerPlugin.GetCutStartOffset());
+                    AppendFloat(sb, PiPDisablerPlugin.GetCutLength());
+                    AppendFloat(sb, PiPDisablerPlugin.GetNearPreserveDepth());
+                    AppendFloat(sb, PiPDisablerPlugin.GetPlane2PositionNormalized(PiPDisablerPlugin.GetCutLength()));
+                    AppendFloat(sb, PiPDisablerPlugin.GetPlane2Radius());
+                    AppendFloat(sb, PiPDisablerPlugin.GetPlane3Position());
+                    AppendFloat(sb, PiPDisablerPlugin.GetPlane3Radius());
+                    AppendFloat(sb, PiPDisablerPlugin.GetPlane4Position());
+                    AppendFloat(sb, PiPDisablerPlugin.GetPlane4Radius());
+                    AppendFloat(sb, PiPDisablerPlugin.GetPlane1OffsetMeters());
                 }
                 else
                 {
-                    AppendFloat(sb, ScopeHousingMeshSurgeryPlugin.GetPlaneOffsetMeters());
+                    AppendFloat(sb, PiPDisablerPlugin.GetPlaneOffsetMeters());
                 }
 
                 using (var sha = SHA256.Create())
@@ -241,7 +241,7 @@ namespace ScopeHousingMeshSurgery
 
             private static string GetPath(string key)
             {
-                return Path.Combine(ScopeHousingMeshSurgeryPlugin.GetMeshCutCacheDirectory(), key + ".bin");
+                return Path.Combine(PiPDisablerPlugin.GetMeshCutCacheDirectory(), key + ".bin");
             }
 
             private static string GetRelativePath(Transform root, Transform child)
@@ -304,14 +304,14 @@ namespace ScopeHousingMeshSurgery
             if (!ScopeHierarchy.TryGetPlane(os, scopeRoot, activeMode,
                 out var planePoint, out var planeNormal, out var camPos))
             {
-                ScopeHousingMeshSurgeryPlugin.LogVerbose("[MeshSurgery] TryGetPlane failed — no plane found.");
+                PiPDisablerPlugin.LogVerbose("[MeshSurgery] TryGetPlane failed — no plane found.");
                 return;
             }
 
-            bool isCylinderMode = ScopeHousingMeshSurgeryPlugin.GetCutMode() == "Cylinder";
+            bool isCylinderMode = PiPDisablerPlugin.GetCutMode() == "Cylinder";
             float plane1Offset = isCylinderMode
-                ? ScopeHousingMeshSurgeryPlugin.GetPlane1OffsetMeters()
-                : ScopeHousingMeshSurgeryPlugin.GetPlaneOffsetMeters();
+                ? PiPDisablerPlugin.GetPlane1OffsetMeters()
+                : PiPDisablerPlugin.GetPlaneOffsetMeters();
             planePoint += planeNormal * plane1Offset;
 
             bool keepPositive = DecideKeepPositive(planePoint, planeNormal, camPos);
@@ -319,14 +319,14 @@ namespace ScopeHousingMeshSurgery
                 ? MeshPlaneCutter.KeepSide.Positive
                 : MeshPlaneCutter.KeepSide.Negative;
 
-            ScopeHousingMeshSurgeryPlugin.LogVerbose(
+            PiPDisablerPlugin.LogVerbose(
                 $"[MeshSurgery] Plane: point={planePoint:F4} normal={planeNormal:F4} keepSide={keepSide}");
 
             // Show visualizer (if enabled)
             PlaneVisualizer.Show(planePoint, planeNormal);
 
             var targets = ScopeHierarchy.FindTargetMeshFilters(scopeRoot, activeMode);
-            float cutRadius = ScopeHousingMeshSurgeryPlugin.GetCutRadius();
+            float cutRadius = PiPDisablerPlugin.GetCutRadius();
 
             foreach (var mf in targets)
             {
@@ -339,7 +339,7 @@ namespace ScopeHousingMeshSurgery
                     float dist = Vector3.Distance(boundsCenter, planePoint);
                     if (dist > cutRadius)
                     {
-                        ScopeHousingMeshSurgeryPlugin.LogVerbose(
+                        PiPDisablerPlugin.LogVerbose(
                             $"[MeshSurgery] Skipping '{mf.sharedMesh.name}' — dist={dist:F4} > radius={cutRadius:F4}");
                         continue;
                     }
@@ -354,7 +354,7 @@ namespace ScopeHousingMeshSurgery
 
                 try
                 {
-                    bool isCylinder = ScopeHousingMeshSurgeryPlugin.GetCutMode() == "Cylinder";
+                    bool isCylinder = PiPDisablerPlugin.GetCutMode() == "Cylinder";
                     string cacheKey = MeshCutCache.BuildKey(scopeRoot, activeMode, mf, originalAsset, keepSide, isCylinder);
 
                     Mesh readable;
@@ -362,7 +362,7 @@ namespace ScopeHousingMeshSurgery
                     {
                         readable = cachedMesh;
                         readable.name = originalAsset.name + "_CUT_CACHED";
-                        ScopeHousingMeshSurgeryPlugin.LogVerbose(
+                        PiPDisablerPlugin.LogVerbose(
                             $"[MeshSurgery] Loaded cached cut mesh for '{originalAsset.name}'.");
                     }
                     else
@@ -371,7 +371,7 @@ namespace ScopeHousingMeshSurgery
                         readable = MeshPlaneCutter.MakeReadableMeshCopy(originalAsset);
                         if (readable == null)
                         {
-                            ScopeHousingMeshSurgeryPlugin.LogVerbose(
+                            PiPDisablerPlugin.LogVerbose(
                                 $"[MeshSurgery] GPU copy returned null for '{originalAsset.name}' — skipping.");
                             continue;
                         }
@@ -381,7 +381,7 @@ namespace ScopeHousingMeshSurgery
                         if (!_loggedGpuCopy)
                         {
                             _loggedGpuCopy = true;
-                            ScopeHousingMeshSurgeryPlugin.LogInfo(
+                            PiPDisablerPlugin.LogInfo(
                                 "[MeshSurgery] Created readable mesh copies via GPU buffer. Plane cutting enabled.");
                         }
 
@@ -392,23 +392,23 @@ namespace ScopeHousingMeshSurgery
 
                         if (isCylinder)
                         {
-                            float nearR = ScopeHousingMeshSurgeryPlugin.GetCylinderRadius();
-                            float startOff = ScopeHousingMeshSurgeryPlugin.GetCutStartOffset();
-                            float cutLen = ScopeHousingMeshSurgeryPlugin.GetCutLength();
-                            float preserve = ScopeHousingMeshSurgeryPlugin.GetNearPreserveDepth();
-                            float p2 = ScopeHousingMeshSurgeryPlugin.GetPlane2PositionNormalized(cutLen);
-                            float r2 = ScopeHousingMeshSurgeryPlugin.GetPlane2Radius();
-                            float p3 = ScopeHousingMeshSurgeryPlugin.GetPlane3Position();
-                            float r3 = ScopeHousingMeshSurgeryPlugin.GetPlane3Radius();
-                            float p4 = ScopeHousingMeshSurgeryPlugin.GetPlane4Position();
-                            float r4 = ScopeHousingMeshSurgeryPlugin.GetPlane4Radius();
+                            float nearR = PiPDisablerPlugin.GetCylinderRadius();
+                            float startOff = PiPDisablerPlugin.GetCutStartOffset();
+                            float cutLen = PiPDisablerPlugin.GetCutLength();
+                            float preserve = PiPDisablerPlugin.GetNearPreserveDepth();
+                            float p2 = PiPDisablerPlugin.GetPlane2PositionNormalized(cutLen);
+                            float r2 = PiPDisablerPlugin.GetPlane2Radius();
+                            float p3 = PiPDisablerPlugin.GetPlane3Position();
+                            float r3 = PiPDisablerPlugin.GetPlane3Radius();
+                            float p4 = PiPDisablerPlugin.GetPlane4Position();
+                            float r4 = PiPDisablerPlugin.GetPlane4Radius();
 
                             ok = MeshPlaneCutter.CutMeshFrustum(readable, mf.transform,
                                 planePoint, planeNormal, nearR, r4, startOff, cutLen,
                                 keepInside: false, midRadius: r2, midPosition: p2,
                                 nearPreserveDepth: preserve,
                                 plane3Radius: r3, plane3Position: p3, plane4Position: p4);
-                            ScopeHousingMeshSurgeryPlugin.LogVerbose(
+                            PiPDisablerPlugin.LogVerbose(
                                 $"[MeshSurgery] Frustum cut '{originalAsset.name}': p1R={nearR:F4}@0.00 " +
                                 $"p2R={r2:F4}@{p2:F2} p3R={r3:F4}@{p3:F2} p4R={r4:F4}@{p4:F2} " +
                                 $"start={startOff:F4} len={cutLen:F4} offset={plane1Offset:F4}" +
@@ -425,7 +425,7 @@ namespace ScopeHousingMeshSurgery
                             // Cut removed everything — clear the mesh to make it empty
                             readable.Clear();
                             readable.name = originalAsset.name + "_CUT_EMPTY";
-                            ScopeHousingMeshSurgeryPlugin.LogVerbose(
+                            PiPDisablerPlugin.LogVerbose(
                                 $"[MeshSurgery] Cut removed all geometry from '{originalAsset.name}' — applying empty mesh.");
                         }
                         else
@@ -433,7 +433,7 @@ namespace ScopeHousingMeshSurgery
                             readable.name = originalAsset.name + "_CUT";
                         }
 
-                        ScopeHousingMeshSurgeryPlugin.LogVerbose(
+                        PiPDisablerPlugin.LogVerbose(
                             $"[MeshSurgery] Cut '{originalAsset.name}': {vertsBefore} → {readable.vertexCount} verts");
 
                         MeshCutCache.Save(cacheKey, readable);
@@ -452,7 +452,7 @@ namespace ScopeHousingMeshSurgery
                 }
                 catch (Exception ex)
                 {
-                    ScopeHousingMeshSurgeryPlugin.LogError(
+                    PiPDisablerPlugin.LogError(
                         $"[MeshSurgery] Failed on '{originalAsset.name}': {ex.Message}");
                 }
             }
@@ -479,7 +479,7 @@ namespace ScopeHousingMeshSurgery
 
             // Mirror the ExpandSearchToWeaponRoot expansion from FindTargetMeshFilters
             // so weapon-body meshes that were cut can also be restored.
-            if (ScopeHousingMeshSurgeryPlugin.GetExpandSearchToWeaponRoot())
+            if (PiPDisablerPlugin.GetExpandSearchToWeaponRoot())
             {
                 for (var p = searchRoot.parent; p != null; p = p.parent)
                 {
@@ -497,7 +497,7 @@ namespace ScopeHousingMeshSurgery
 
             if (toRestore.Length == 0) return;
 
-            ScopeHousingMeshSurgeryPlugin.LogVerbose(
+            PiPDisablerPlugin.LogVerbose(
                 $"[MeshSurgery] RestoreForScope: {toRestore.Length} meshes to restore (searchRoot='{searchRoot.name}')");
 
             foreach (var mf in toRestore)
@@ -509,7 +509,7 @@ namespace ScopeHousingMeshSurgery
             var keys = _tracked.Keys.ToArray();
             if (keys.Length == 0) return;
 
-            ScopeHousingMeshSurgeryPlugin.LogVerbose(
+            PiPDisablerPlugin.LogVerbose(
                 $"[MeshSurgery] RestoreAll: {keys.Length} meshes to restore");
 
             foreach (var mf in keys)
@@ -525,12 +525,12 @@ namespace ScopeHousingMeshSurgery
             try
             {
                 mf.sharedMesh = st.OriginalAssetMesh;
-                ScopeHousingMeshSurgeryPlugin.LogVerbose(
+                PiPDisablerPlugin.LogVerbose(
                     $"[MeshSurgery] Restored '{st.OriginalAssetMesh?.name}' on {mf.gameObject.name}");
             }
             catch (Exception ex)
             {
-                ScopeHousingMeshSurgeryPlugin.LogError(
+                PiPDisablerPlugin.LogError(
                     $"[MeshSurgery] Restore failed: {ex.Message}");
             }
 
@@ -575,7 +575,7 @@ namespace ScopeHousingMeshSurgery
             {
                 if (HasDirectChild(t, "backLens") || HasDirectChild(t, "backlens"))
                 {
-                    ScopeHousingMeshSurgeryPlugin.LogVerbose(
+                    PiPDisablerPlugin.LogVerbose(
                         $"[ScopeHierarchy] FindScopeRoot fallback (backLens child): '{t.name}'");
                     return t;
                 }
@@ -589,14 +589,14 @@ namespace ScopeHousingMeshSurgery
                     var lo = t.name.ToLowerInvariant();
                     if (lo.Contains("scope"))
                     {
-                        ScopeHousingMeshSurgeryPlugin.LogVerbose(
+                        PiPDisablerPlugin.LogVerbose(
                             $"[ScopeHierarchy] FindScopeRoot fallback (name match): '{t.name}'");
                         return t;
                     }
                 }
             }
 
-            ScopeHousingMeshSurgeryPlugin.LogVerbose(
+            PiPDisablerPlugin.LogVerbose(
                 $"[ScopeHierarchy] FindScopeRoot FAILED for '{any?.name}' — no scope root found");
             return null;
         }
@@ -699,7 +699,7 @@ namespace ScopeHousingMeshSurgery
             try { viewerTf = os != null ? os.ScopeTransform : null; } catch { }
 
             if (viewerTf != null) camPos = viewerTf.position;
-            else { var mc = ScopeHousingMeshSurgeryPlugin.GetMainCamera(); camPos = mc != null ? mc.transform.position : activeMode.position; }
+            else { var mc = PiPDisablerPlugin.GetMainCamera(); camPos = mc != null ? mc.transform.position : activeMode.position; }
 
             // Find the best reference transform for the cut plane.
             Transform refTransform = null;
@@ -757,9 +757,9 @@ namespace ScopeHousingMeshSurgery
             // Determine the plane normal based on config.
             planeNormal = GetConfiguredNormal(refTransform);
 
-            ScopeHousingMeshSurgeryPlugin.LogVerbose(
+            PiPDisablerPlugin.LogVerbose(
                 $"[ScopeHierarchy] TryGetPlane: ref='{refTransform.name}', " +
-                $"axis={ScopeHousingMeshSurgeryPlugin.GetPlaneNormalAxis()}, " +
+                $"axis={PiPDisablerPlugin.GetPlaneNormalAxis()}, " +
                 $"normal={planeNormal:F3}");
 
             return true;
@@ -772,7 +772,7 @@ namespace ScopeHousingMeshSurgery
         /// </summary>
         private static Vector3 GetConfiguredNormal(Transform refTransform)
         {
-            string axis = ScopeHousingMeshSurgeryPlugin.GetPlaneNormalAxis() ?? "Auto";
+            string axis = PiPDisablerPlugin.GetPlaneNormalAxis() ?? "Auto";
 
             switch (axis)
             {
@@ -830,7 +830,7 @@ namespace ScopeHousingMeshSurgery
                 break; // unknown parent — stop
             }
             if (searchRoot != scopeRoot)
-                ScopeHousingMeshSurgeryPlugin.LogVerbose(
+                PiPDisablerPlugin.LogVerbose(
                     $"[ScopeHierarchy] Expanded search root: '{scopeRoot.name}' → '{searchRoot.name}'");
 
             // Optional: climb further up to the Weapon_root node to include weapon body meshes.
@@ -838,14 +838,14 @@ namespace ScopeHousingMeshSurgery
             // With ExpandSearchToWeaponRoot the search climbs through those intermediate nodes
             // until it finds a transform whose name starts with "Weapon_root".
             // Path example: Weapon_root/Weapon_root_anim/weapon/mod_scope/<scope>
-            if (ScopeHousingMeshSurgeryPlugin.GetExpandSearchToWeaponRoot())
+            if (PiPDisablerPlugin.GetExpandSearchToWeaponRoot())
             {
                 for (var p = searchRoot.parent; p != null; p = p.parent)
                 {
                     if ((p.name ?? "").StartsWith("Weapon_root", StringComparison.OrdinalIgnoreCase))
                     {
                         searchRoot = p;
-                        ScopeHousingMeshSurgeryPlugin.LogVerbose(
+                        PiPDisablerPlugin.LogVerbose(
                             $"[ScopeHierarchy] ExpandSearchToWeaponRoot: climbed to '{searchRoot.name}'");
                         break;
                     }
@@ -858,7 +858,7 @@ namespace ScopeHousingMeshSurgery
             {
                 CollectOtherScopeRoots(searchRoot, scopeRoot, otherScopeRoots);
                 if (otherScopeRoots.Count > 0)
-                    ScopeHousingMeshSurgeryPlugin.LogVerbose(
+                    PiPDisablerPlugin.LogVerbose(
                         $"[ScopeHierarchy] Found {otherScopeRoots.Count} sibling scope root(s) — will exclude their subtrees");
             }
 
@@ -888,7 +888,7 @@ namespace ScopeHousingMeshSurgery
                 result.Add(mf);
             }
 
-            ScopeHousingMeshSurgeryPlugin.LogVerbose(
+            PiPDisablerPlugin.LogVerbose(
                 $"[ScopeHierarchy] FindTargets from '{searchRoot.name}': " +
                 $"{result.Count} targets, skipped: mode={skippedMode} otherScope={skippedOther}");
 

--- a/Patches/PWAMethod23Patch.cs
+++ b/Patches/PWAMethod23Patch.cs
@@ -6,7 +6,7 @@ using EFT.CameraControl;
 using HarmonyLib;
 using SPT.Reflection.Patching;
 
-namespace ScopeHousingMeshSurgery.Patches
+namespace PiPDisabler.Patches
 {
     /// <summary>
     /// Rewrites ProceduralWeaponAnimation.method_23's SetFov call in-place so
@@ -56,8 +56,8 @@ namespace ScopeHousingMeshSurgery.Patches
                 return;
 
             if (pwa != null &&
-                ScopeHousingMeshSurgeryPlugin.ModEnabled.Value &&
-                ScopeHousingMeshSurgeryPlugin.EnableZoom.Value &&
+                PiPDisablerPlugin.ModEnabled.Value &&
+                PiPDisablerPlugin.EnableZoom.Value &&
                 ScopeLifecycle.IsScoped &&
                 !ScopeLifecycle.IsModBypassedForCurrentScope &&
                 pwa.IsAiming &&

--- a/Patches/Patcher.cs
+++ b/Patches/Patcher.cs
@@ -1,7 +1,7 @@
 using System;
 using SPT.Reflection.Patching;
 
-namespace ScopeHousingMeshSurgery.Patches
+namespace PiPDisabler.Patches
 {
     internal static class Patcher
     {
@@ -37,7 +37,7 @@ namespace ScopeHousingMeshSurgery.Patches
             }
             catch (Exception ex)
             {
-                ScopeHousingMeshSurgeryPlugin.LogError($"[Patcher] Failed to enable {typeof(T).Name}: {ex.Message}");
+                PiPDisablerPlugin.LogError($"[Patcher] Failed to enable {typeof(T).Name}: {ex.Message}");
             }
         }
     }

--- a/Patches/PerScopeMeshSurgerySettings.cs
+++ b/Patches/PerScopeMeshSurgerySettings.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using Newtonsoft.Json;
 
-namespace ScopeHousingMeshSurgery
+namespace PiPDisabler
 {
     [Serializable]
     internal sealed class ScopeMeshSurgerySettingsEntry
@@ -49,7 +49,7 @@ namespace ScopeHousingMeshSurgery
         private static bool _loaded;
         private static string _activeScopeKey;
 
-        private static string FilePath => Path.Combine(ScopeHousingMeshSurgeryPlugin.GetMeshCutCacheDirectory(), "custom_mesh_surgery_settings.json");
+        private static string FilePath => Path.Combine(PiPDisablerPlugin.GetMeshCutCacheDirectory(), "custom_mesh_surgery_settings.json");
 
         internal static void SetActiveScope(string scopeKey)
         {
@@ -69,39 +69,39 @@ namespace ScopeHousingMeshSurgery
 
             try
             {
-                ScopeHousingMeshSurgeryPlugin.CustomPlaneOffsetMeters.Value = entry.PlaneOffsetMeters;
+                PiPDisablerPlugin.CustomPlaneOffsetMeters.Value = entry.PlaneOffsetMeters;
                 if (!string.IsNullOrWhiteSpace(entry.PlaneNormalAxis))
-                    ScopeHousingMeshSurgeryPlugin.CustomPlaneNormalAxis.Value = entry.PlaneNormalAxis;
-                ScopeHousingMeshSurgeryPlugin.CustomCutRadius.Value = entry.CutRadius;
-                ScopeHousingMeshSurgeryPlugin.CustomShowCutPlane.Value = entry.ShowCutPlane;
-                ScopeHousingMeshSurgeryPlugin.CustomShowCutVolume.Value = entry.ShowCutVolume;
-                ScopeHousingMeshSurgeryPlugin.CustomCutVolumeOpacity.Value = entry.CutVolumeOpacity;
+                    PiPDisablerPlugin.CustomPlaneNormalAxis.Value = entry.PlaneNormalAxis;
+                PiPDisablerPlugin.CustomCutRadius.Value = entry.CutRadius;
+                PiPDisablerPlugin.CustomShowCutPlane.Value = entry.ShowCutPlane;
+                PiPDisablerPlugin.CustomShowCutVolume.Value = entry.ShowCutVolume;
+                PiPDisablerPlugin.CustomCutVolumeOpacity.Value = entry.CutVolumeOpacity;
                 if (!string.IsNullOrWhiteSpace(entry.CutMode))
-                    ScopeHousingMeshSurgeryPlugin.CustomCutMode.Value = entry.CutMode;
-                ScopeHousingMeshSurgeryPlugin.CustomCylinderRadius.Value = entry.CylinderRadius;
-                ScopeHousingMeshSurgeryPlugin.CustomMidCylinderRadius.Value = entry.MidCylinderRadius;
-                ScopeHousingMeshSurgeryPlugin.CustomMidCylinderPosition.Value = entry.MidCylinderPosition;
-                ScopeHousingMeshSurgeryPlugin.CustomFarCylinderRadius.Value = entry.FarCylinderRadius;
-                ScopeHousingMeshSurgeryPlugin.CustomPlane1OffsetMeters.Value = entry.Plane1OffsetMeters;
-                ScopeHousingMeshSurgeryPlugin.CustomPlane2Position.Value = entry.Plane2Position;
-                ScopeHousingMeshSurgeryPlugin.CustomPlane2Radius.Value = entry.Plane2Radius;
-                ScopeHousingMeshSurgeryPlugin.CustomPlane3Position.Value = entry.Plane3Position;
-                ScopeHousingMeshSurgeryPlugin.CustomPlane3Radius.Value = entry.Plane3Radius;
-                ScopeHousingMeshSurgeryPlugin.CustomPlane4Position.Value = entry.Plane4Position;
-                ScopeHousingMeshSurgeryPlugin.CustomPlane4Radius.Value = entry.Plane4Radius;
-                ScopeHousingMeshSurgeryPlugin.CustomCutStartOffset.Value = entry.CutStartOffset;
-                ScopeHousingMeshSurgeryPlugin.CustomCutLength.Value = entry.CutLength;
-                ScopeHousingMeshSurgeryPlugin.CustomNearPreserveDepth.Value = entry.NearPreserveDepth;
-                ScopeHousingMeshSurgeryPlugin.CustomShowReticle.Value = entry.ShowReticle;
-                ScopeHousingMeshSurgeryPlugin.CustomReticleBaseSize.Value = entry.ReticleBaseSize;
-                ScopeHousingMeshSurgeryPlugin.CustomReticleOverlayCamera.Value = entry.ReticleOverlayCamera;
-                ScopeHousingMeshSurgeryPlugin.CustomRestoreOnUnscope.Value = entry.RestoreOnUnscope;
-                ScopeHousingMeshSurgeryPlugin.CustomExpandSearchToWeaponRoot.Value = entry.ExpandSearchToWeaponRoot;
-                ScopeHousingMeshSurgeryPlugin.LogInfo($"[CustomMeshSettings] Loaded saved settings for scope '{entry.ScopeKey}' into Custom config entries.");
+                    PiPDisablerPlugin.CustomCutMode.Value = entry.CutMode;
+                PiPDisablerPlugin.CustomCylinderRadius.Value = entry.CylinderRadius;
+                PiPDisablerPlugin.CustomMidCylinderRadius.Value = entry.MidCylinderRadius;
+                PiPDisablerPlugin.CustomMidCylinderPosition.Value = entry.MidCylinderPosition;
+                PiPDisablerPlugin.CustomFarCylinderRadius.Value = entry.FarCylinderRadius;
+                PiPDisablerPlugin.CustomPlane1OffsetMeters.Value = entry.Plane1OffsetMeters;
+                PiPDisablerPlugin.CustomPlane2Position.Value = entry.Plane2Position;
+                PiPDisablerPlugin.CustomPlane2Radius.Value = entry.Plane2Radius;
+                PiPDisablerPlugin.CustomPlane3Position.Value = entry.Plane3Position;
+                PiPDisablerPlugin.CustomPlane3Radius.Value = entry.Plane3Radius;
+                PiPDisablerPlugin.CustomPlane4Position.Value = entry.Plane4Position;
+                PiPDisablerPlugin.CustomPlane4Radius.Value = entry.Plane4Radius;
+                PiPDisablerPlugin.CustomCutStartOffset.Value = entry.CutStartOffset;
+                PiPDisablerPlugin.CustomCutLength.Value = entry.CutLength;
+                PiPDisablerPlugin.CustomNearPreserveDepth.Value = entry.NearPreserveDepth;
+                PiPDisablerPlugin.CustomShowReticle.Value = entry.ShowReticle;
+                PiPDisablerPlugin.CustomReticleBaseSize.Value = entry.ReticleBaseSize;
+                PiPDisablerPlugin.CustomReticleOverlayCamera.Value = entry.ReticleOverlayCamera;
+                PiPDisablerPlugin.CustomRestoreOnUnscope.Value = entry.RestoreOnUnscope;
+                PiPDisablerPlugin.CustomExpandSearchToWeaponRoot.Value = entry.ExpandSearchToWeaponRoot;
+                PiPDisablerPlugin.LogInfo($"[CustomMeshSettings] Loaded saved settings for scope '{entry.ScopeKey}' into Custom config entries.");
             }
             catch (Exception ex)
             {
-                ScopeHousingMeshSurgeryPlugin.LogWarn($"[CustomMeshSettings] Failed to sync Custom config entries from override: {ex.Message}");
+                PiPDisablerPlugin.LogWarn($"[CustomMeshSettings] Failed to sync Custom config entries from override: {ex.Message}");
             }
         }
 
@@ -154,32 +154,32 @@ namespace ScopeHousingMeshSurgery
                 _file.Entries.Add(target);
             }
 
-            target.PlaneOffsetMeters = ScopeHousingMeshSurgeryPlugin.CustomPlaneOffsetMeters.Value;
-            target.PlaneNormalAxis = ScopeHousingMeshSurgeryPlugin.CustomPlaneNormalAxis.Value;
-            target.CutRadius = ScopeHousingMeshSurgeryPlugin.CustomCutRadius.Value;
-            target.ShowCutPlane = ScopeHousingMeshSurgeryPlugin.CustomShowCutPlane.Value;
-            target.ShowCutVolume = ScopeHousingMeshSurgeryPlugin.CustomShowCutVolume.Value;
-            target.CutVolumeOpacity = ScopeHousingMeshSurgeryPlugin.CustomCutVolumeOpacity.Value;
-            target.CutMode = ScopeHousingMeshSurgeryPlugin.CustomCutMode.Value;
-            target.CylinderRadius = ScopeHousingMeshSurgeryPlugin.CustomCylinderRadius.Value;
-            target.MidCylinderRadius = ScopeHousingMeshSurgeryPlugin.CustomMidCylinderRadius.Value;
-            target.MidCylinderPosition = ScopeHousingMeshSurgeryPlugin.CustomMidCylinderPosition.Value;
-            target.FarCylinderRadius = ScopeHousingMeshSurgeryPlugin.CustomFarCylinderRadius.Value;
-            target.Plane1OffsetMeters = ScopeHousingMeshSurgeryPlugin.CustomPlane1OffsetMeters.Value;
-            target.Plane2Position = ScopeHousingMeshSurgeryPlugin.CustomPlane2Position.Value;
-            target.Plane2Radius = ScopeHousingMeshSurgeryPlugin.CustomPlane2Radius.Value;
-            target.Plane3Position = ScopeHousingMeshSurgeryPlugin.CustomPlane3Position.Value;
-            target.Plane3Radius = ScopeHousingMeshSurgeryPlugin.CustomPlane3Radius.Value;
-            target.Plane4Position = ScopeHousingMeshSurgeryPlugin.CustomPlane4Position.Value;
-            target.Plane4Radius = ScopeHousingMeshSurgeryPlugin.CustomPlane4Radius.Value;
-            target.CutStartOffset = ScopeHousingMeshSurgeryPlugin.CustomCutStartOffset.Value;
-            target.CutLength = ScopeHousingMeshSurgeryPlugin.CustomCutLength.Value;
-            target.NearPreserveDepth = ScopeHousingMeshSurgeryPlugin.CustomNearPreserveDepth.Value;
-            target.ShowReticle = ScopeHousingMeshSurgeryPlugin.CustomShowReticle.Value;
-            target.ReticleBaseSize = ScopeHousingMeshSurgeryPlugin.CustomReticleBaseSize.Value;
-            target.ReticleOverlayCamera = ScopeHousingMeshSurgeryPlugin.CustomReticleOverlayCamera.Value;
-            target.RestoreOnUnscope = ScopeHousingMeshSurgeryPlugin.CustomRestoreOnUnscope.Value;
-            target.ExpandSearchToWeaponRoot = ScopeHousingMeshSurgeryPlugin.CustomExpandSearchToWeaponRoot.Value;
+            target.PlaneOffsetMeters = PiPDisablerPlugin.CustomPlaneOffsetMeters.Value;
+            target.PlaneNormalAxis = PiPDisablerPlugin.CustomPlaneNormalAxis.Value;
+            target.CutRadius = PiPDisablerPlugin.CustomCutRadius.Value;
+            target.ShowCutPlane = PiPDisablerPlugin.CustomShowCutPlane.Value;
+            target.ShowCutVolume = PiPDisablerPlugin.CustomShowCutVolume.Value;
+            target.CutVolumeOpacity = PiPDisablerPlugin.CustomCutVolumeOpacity.Value;
+            target.CutMode = PiPDisablerPlugin.CustomCutMode.Value;
+            target.CylinderRadius = PiPDisablerPlugin.CustomCylinderRadius.Value;
+            target.MidCylinderRadius = PiPDisablerPlugin.CustomMidCylinderRadius.Value;
+            target.MidCylinderPosition = PiPDisablerPlugin.CustomMidCylinderPosition.Value;
+            target.FarCylinderRadius = PiPDisablerPlugin.CustomFarCylinderRadius.Value;
+            target.Plane1OffsetMeters = PiPDisablerPlugin.CustomPlane1OffsetMeters.Value;
+            target.Plane2Position = PiPDisablerPlugin.CustomPlane2Position.Value;
+            target.Plane2Radius = PiPDisablerPlugin.CustomPlane2Radius.Value;
+            target.Plane3Position = PiPDisablerPlugin.CustomPlane3Position.Value;
+            target.Plane3Radius = PiPDisablerPlugin.CustomPlane3Radius.Value;
+            target.Plane4Position = PiPDisablerPlugin.CustomPlane4Position.Value;
+            target.Plane4Radius = PiPDisablerPlugin.CustomPlane4Radius.Value;
+            target.CutStartOffset = PiPDisablerPlugin.CustomCutStartOffset.Value;
+            target.CutLength = PiPDisablerPlugin.CustomCutLength.Value;
+            target.NearPreserveDepth = PiPDisablerPlugin.CustomNearPreserveDepth.Value;
+            target.ShowReticle = PiPDisablerPlugin.CustomShowReticle.Value;
+            target.ReticleBaseSize = PiPDisablerPlugin.CustomReticleBaseSize.Value;
+            target.ReticleOverlayCamera = PiPDisablerPlugin.CustomReticleOverlayCamera.Value;
+            target.RestoreOnUnscope = PiPDisablerPlugin.CustomRestoreOnUnscope.Value;
+            target.ExpandSearchToWeaponRoot = PiPDisablerPlugin.CustomExpandSearchToWeaponRoot.Value;
 
             WriteToDisk();
             return true;
@@ -228,7 +228,7 @@ namespace ScopeHousingMeshSurgery
             }
             catch (Exception ex)
             {
-                ScopeHousingMeshSurgeryPlugin.LogWarn($"[CustomMeshSettings] Failed to load settings json: {ex.Message}");
+                PiPDisablerPlugin.LogWarn($"[CustomMeshSettings] Failed to load settings json: {ex.Message}");
                 _file = new ScopeMeshSurgerySettingsFile();
             }
         }
@@ -242,7 +242,7 @@ namespace ScopeHousingMeshSurgery
             }
             catch (Exception ex)
             {
-                ScopeHousingMeshSurgeryPlugin.LogError($"[CustomMeshSettings] Failed to save settings json: {ex.Message}");
+                PiPDisablerPlugin.LogError($"[CustomMeshSettings] Failed to save settings json: {ex.Message}");
             }
         }
     }

--- a/Patches/PiPDisabler.cs
+++ b/Patches/PiPDisabler.cs
@@ -7,7 +7,7 @@ using SPT.Reflection.Patching;
 using UnityEngine;
 using System.Reflection.Emit;
 
-namespace ScopeHousingMeshSurgery
+namespace PiPDisabler
 {
     internal static class PiPDisabler
     {
@@ -61,7 +61,7 @@ namespace ScopeHousingMeshSurgery
 
 internal static void TickBaseOpticCamera()
         {
-            if (!ScopeHousingMeshSurgeryPlugin.DisablePiP.Value) return;
+            if (!PiPDisablerPlugin.DisablePiP.Value) return;
 
             // Any condition that should preserve vanilla PiP must restore and skip disabling.
             if (ShouldAllowVanillaPiP())
@@ -176,7 +176,7 @@ internal static bool ShouldIgnoreOnDisable(OpticSight os)
                         if (!_loggedBase)
                         {
                             _loggedBase = true;
-                            ScopeHousingMeshSurgeryPlugin.LogInfo(
+                            PiPDisablerPlugin.LogInfo(
                                 $"[PiPDisabler] Found BaseOpticCamera: {n} (cameras: {_baseOpticCams.Count})");
                         }
                         break;
@@ -205,7 +205,7 @@ internal static bool ShouldIgnoreOnDisable(OpticSight os)
                 if (ScopeLifecycle.IsNameBypassed(os))
                     return true;
 
-                if (!ScopeHousingMeshSurgeryPlugin.AutoDisableForVariableScopes.Value)
+                if (!PiPDisablerPlugin.AutoDisableForVariableScopes.Value)
                     return false;
 
                 if (FovController.IsOpticAdjustable(os))
@@ -232,13 +232,13 @@ internal static bool ShouldIgnoreOnDisable(OpticSight os)
                     if (f.FieldType == typeof(OpticSight))
                     {
                         _opticSightField = f;
-                        ScopeHousingMeshSurgeryPlugin.LogInfo(
+                        PiPDisablerPlugin.LogInfo(
                             $"[PiPDisabler] Found OpticSight field on OpticComponentUpdater: '{f.Name}'");
                         break;
                     }
                 }
                 if (_opticSightField == null)
-                    ScopeHousingMeshSurgeryPlugin.LogWarn(
+                    PiPDisablerPlugin.LogWarn(
                         "[PiPDisabler] Could not find any OpticSight field on OpticComponentUpdater!");
             }
             return _opticSightField;
@@ -318,8 +318,8 @@ _ignoreOnDisableFrame.Clear();
 
         private static bool ShouldAllowVanillaPiP()
         {
-            return !ScopeHousingMeshSurgeryPlugin.ModEnabled.Value
-                || !ScopeHousingMeshSurgeryPlugin.DisablePiP.Value
+            return !PiPDisablerPlugin.ModEnabled.Value
+                || !PiPDisablerPlugin.DisablePiP.Value
                 || ScopeLifecycle.IsModBypassedForCurrentScope
                 || ScopeLifecycle.IsLastOpticNameBypassed();
         }
@@ -332,8 +332,8 @@ _ignoreOnDisableFrame.Clear();
             [PatchPostfix]
             private static void Postfix(OpticComponentUpdater __instance)
             {
-                if (!ScopeHousingMeshSurgeryPlugin.ModEnabled.Value) return;
-                if (!ScopeHousingMeshSurgeryPlugin.DisablePiP.Value) return;
+                if (!PiPDisablerPlugin.ModEnabled.Value) return;
+                if (!PiPDisablerPlugin.DisablePiP.Value) return;
                 if (__instance == null) return;
                 if (ShouldSuppressPiPDisableForCurrentOptic(__instance)) return;
 
@@ -356,10 +356,10 @@ _ignoreOnDisableFrame.Clear();
             [PatchPrefix]
             private static bool Prefix(OpticComponentUpdater __instance)
             {
-                if (!ScopeHousingMeshSurgeryPlugin.ModEnabled.Value) return true;
+                if (!PiPDisablerPlugin.ModEnabled.Value) return true;
                 if (__instance == null) return true;
 
-                if (ScopeHousingMeshSurgeryPlugin.DisablePiP.Value)
+                if (PiPDisablerPlugin.DisablePiP.Value)
                 {
                     OpticCameraTransform = __instance.transform;
                     Debug_LastOpticCameraTransform = OpticCameraTransform;

--- a/Patches/PlaneVisualizer.cs
+++ b/Patches/PlaneVisualizer.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using UnityEngine;
 
-namespace ScopeHousingMeshSurgery
+namespace PiPDisabler
 {
     /// <summary>
     /// Visualizes the mesh cutting volume in two modes:
@@ -31,8 +31,8 @@ namespace ScopeHousingMeshSurgery
 
         public static void Show(Vector3 planePoint, Vector3 planeNormal)
         {
-            bool showPlane = ScopeHousingMeshSurgeryPlugin.GetShowCutPlane();
-            bool showVolume = ScopeHousingMeshSurgeryPlugin.GetShowCutVolume();
+            bool showPlane = PiPDisablerPlugin.GetShowCutPlane();
+            bool showVolume = PiPDisablerPlugin.GetShowCutVolume();
 
             if (!showPlane && !showVolume)
             {
@@ -40,9 +40,9 @@ namespace ScopeHousingMeshSurgery
                 return;
             }
 
-            bool isCylinder = ScopeHousingMeshSurgeryPlugin.GetCutMode() == "Cylinder";
-            float startOffset = ScopeHousingMeshSurgeryPlugin.GetCutStartOffset();
-            float cutLength = ScopeHousingMeshSurgeryPlugin.GetCutLength();
+            bool isCylinder = PiPDisablerPlugin.GetCutMode() == "Cylinder";
+            float startOffset = PiPDisablerPlugin.GetCutStartOffset();
+            float cutLength = PiPDisablerPlugin.GetCutLength();
 
             Vector3 nearPos = planePoint - planeNormal * startOffset;
             Vector3 farPos = nearPos + planeNormal * cutLength;
@@ -63,8 +63,8 @@ namespace ScopeHousingMeshSurgery
 
                 if (isCylinder)
                 {
-                    float p1R = ScopeHousingMeshSurgeryPlugin.GetCylinderRadius();
-                    float p4R = ScopeHousingMeshSurgeryPlugin.GetPlane4Radius();
+                    float p1R = PiPDisablerPlugin.GetCylinderRadius();
+                    float p4R = PiPDisablerPlugin.GetPlane4Radius();
 
                     _nearGO.transform.localScale = Vector3.one * p1R * 2f;
                     _farGO.transform.localScale = Vector3.one * p4R * 2f;
@@ -89,14 +89,14 @@ namespace ScopeHousingMeshSurgery
             // --- 3D tube volume (ShowCutVolume) ---
             if (showVolume && isCylinder)
             {
-                float p1R = ScopeHousingMeshSurgeryPlugin.GetCylinderRadius();
-                float p2R = ScopeHousingMeshSurgeryPlugin.GetPlane2Radius();
-                float p2Pos = ScopeHousingMeshSurgeryPlugin.GetPlane2PositionNormalized(cutLength);
-                float p3R = ScopeHousingMeshSurgeryPlugin.GetPlane3Radius();
-                float p3Pos = ScopeHousingMeshSurgeryPlugin.GetPlane3Position();
-                float p4R = ScopeHousingMeshSurgeryPlugin.GetPlane4Radius();
-                float p4Pos = ScopeHousingMeshSurgeryPlugin.GetPlane4Position();
-                float opacity = ScopeHousingMeshSurgeryPlugin.GetCutVolumeOpacity();
+                float p1R = PiPDisablerPlugin.GetCylinderRadius();
+                float p2R = PiPDisablerPlugin.GetPlane2Radius();
+                float p2Pos = PiPDisablerPlugin.GetPlane2PositionNormalized(cutLength);
+                float p3R = PiPDisablerPlugin.GetPlane3Radius();
+                float p3Pos = PiPDisablerPlugin.GetPlane3Position();
+                float p4R = PiPDisablerPlugin.GetPlane4Radius();
+                float p4Pos = PiPDisablerPlugin.GetPlane4Position();
+                float opacity = PiPDisablerPlugin.GetCutVolumeOpacity();
 
                 int hash = ComputeTubeHash(p1R, p2R, p2Pos, p3R, p3Pos, p4R, p4Pos, cutLength);
                 EnsureTubeCreated(p1R, p2R, p2Pos, p3R, p3Pos, p4R, p4Pos, cutLength, opacity, hash);
@@ -119,7 +119,7 @@ namespace ScopeHousingMeshSurgery
                 _tubeGO.transform.localScale = Vector3.one;
 
                 // Preserve zone ring — yellow circle at the depth where cutting actually begins
-                float preserve = ScopeHousingMeshSurgeryPlugin.GetNearPreserveDepth();
+                float preserve = PiPDisablerPlugin.GetNearPreserveDepth();
                 if (preserve > 0f)
                 {
                     EnsurePreserveRingCreated();
@@ -176,7 +176,7 @@ namespace ScopeHousingMeshSurgery
             _farMat = MakeMat(new Color(1, 0, 0, 0.35f));
             _nearGO = MakeGO("CutPlaneVis_Near", _nearMat);
             _farGO = MakeGO("CutPlaneVis_Far", _farMat);
-            ScopeHousingMeshSurgeryPlugin.LogInfo("[PlaneVis] Created near (green) + far (red)");
+            PiPDisablerPlugin.LogInfo("[PlaneVis] Created near (green) + far (red)");
         }
 
         private static void EnsurePreserveRingCreated()
@@ -184,7 +184,7 @@ namespace ScopeHousingMeshSurgery
             if (_preserveRingGO != null) return;
             _preserveRingMat = MakeMat(new Color(1, 1, 0, 0.5f)); // yellow
             _preserveRingGO = MakeGO("CutPlaneVis_Preserve", _preserveRingMat);
-            ScopeHousingMeshSurgeryPlugin.LogInfo("[PlaneVis] Created preserve zone ring (yellow)");
+            PiPDisablerPlugin.LogInfo("[PlaneVis] Created preserve zone ring (yellow)");
         }
 
         // ============================
@@ -221,7 +221,7 @@ namespace ScopeHousingMeshSurgery
             {
                 _tubeMat = MakeMat(new Color(0.2f, 0.6f, 1f, opacity));
                 _tubeGO = MakeGO("CutVolumeVis", _tubeMat);
-                ScopeHousingMeshSurgeryPlugin.LogInfo("[PlaneVis] Created 3D cut volume visualizer");
+                PiPDisablerPlugin.LogInfo("[PlaneVis] Created 3D cut volume visualizer");
             }
 
             _tubeGO.GetComponent<MeshFilter>().sharedMesh = _tubeMesh;
@@ -299,7 +299,7 @@ namespace ScopeHousingMeshSurgery
             mesh.SetTriangles(tris, 0);
             mesh.RecalculateBounds();
 
-            ScopeHousingMeshSurgeryPlugin.LogVerbose(
+            PiPDisablerPlugin.LogVerbose(
                 $"[PlaneVis] Generated tube: verts={verts.Count} tris={tris.Count / 3} " +
                 $"p1R={p1R:F4}@0.00 p2R={p2R:F4}@{p2Pos:F2} p3R={p3R:F4}@{p3Pos:F2} p4R={p4R:F4}@{p4Pos:F2} len={cutLen:F3}");
 

--- a/Patches/ReticleRenderer.cs
+++ b/Patches/ReticleRenderer.cs
@@ -3,7 +3,7 @@ using EFT.CameraControl;
 using UnityEngine;
 using UnityEngine.Rendering;
 
-namespace ScopeHousingMeshSurgery
+namespace PiPDisabler
 {
     /// <summary>
     /// Renders the scope reticle via a CommandBuffer injected at
@@ -88,7 +88,7 @@ namespace ScopeHousingMeshSurgery
         /// </summary>
         public static void ExtractReticle(OpticSight os)
         {
-            if (!ScopeHousingMeshSurgeryPlugin.GetShowReticle()) return;
+            if (!PiPDisablerPlugin.GetShowReticle()) return;
             if (os == null) return;
 
             _savedMarkTex = null;
@@ -119,7 +119,7 @@ namespace ScopeHousingMeshSurgery
                     _savedMarkTex.anisoLevel = 16;
                 }
 
-                ScopeHousingMeshSurgeryPlugin.LogInfo(
+                PiPDisablerPlugin.LogInfo(
                     $"[Reticle] Extracted: _MarkTex={(_savedMarkTex != null ? _savedMarkTex.name : "null")} " +
                     $"({(_savedMarkTex != null ? $"{_savedMarkTex.width}x{_savedMarkTex.height}" : "?")}) " +
                     $"_MaskTex={(_savedMaskTex != null ? _savedMaskTex.name : "null")} " +
@@ -127,7 +127,7 @@ namespace ScopeHousingMeshSurgery
             }
             catch (System.Exception e)
             {
-                ScopeHousingMeshSurgeryPlugin.LogError($"[Reticle] Extract failed: {e.Message}");
+                PiPDisablerPlugin.LogError($"[Reticle] Extract failed: {e.Message}");
             }
         }
 
@@ -137,7 +137,7 @@ namespace ScopeHousingMeshSurgery
         /// </summary>
         public static void Show(OpticSight os, float magnification = 1f)
         {
-            if (!ScopeHousingMeshSurgeryPlugin.GetShowReticle()) return;
+            if (!PiPDisablerPlugin.GetShowReticle()) return;
             if (_savedMarkTex == null || os == null) return;
 
             try
@@ -150,10 +150,10 @@ namespace ScopeHousingMeshSurgery
                 ApplyHorizontalFlip();
 
                 // Scale
-                float configBase = ScopeHousingMeshSurgeryPlugin.GetReticleBaseSize();
+                float configBase = PiPDisablerPlugin.GetReticleBaseSize();
                 _baseScale = (configBase > 0f)
                     ? configBase
-                    : ScopeHousingMeshSurgeryPlugin.GetCylinderRadius() * 2f;
+                    : PiPDisablerPlugin.GetCylinderRadius() * 2f;
                 if (_baseScale < 0.001f) _baseScale = 0.030f;
 
                 if (magnification < 1f) magnification = 1f;
@@ -165,13 +165,13 @@ namespace ScopeHousingMeshSurgery
                 _settled = true;
                 _alignmentActive = true;
 
-                ScopeHousingMeshSurgeryPlugin.LogInfo(
+                PiPDisablerPlugin.LogInfo(
                     $"[Reticle] Showing: base={_baseScale:F4} mag={magnification:F1}x " +
                     $"(camera-aligned centered rendering)");
             }
             catch (System.Exception e)
             {
-                ScopeHousingMeshSurgeryPlugin.LogError($"[Reticle] Show failed: {e.Message}");
+                PiPDisablerPlugin.LogError($"[Reticle] Show failed: {e.Message}");
             }
         }
 
@@ -187,7 +187,7 @@ namespace ScopeHousingMeshSurgery
             if (Mathf.Abs(magnification - _lastMag) >= 0.01f)
                 _lastMag = magnification;
 
-            var mainCam = ScopeHousingMeshSurgeryPlugin.GetMainCamera();
+            var mainCam = PiPDisablerPlugin.GetMainCamera();
             if (mainCam != null && mainCam != _attachedCamera)
                 AttachToCamera();
         }
@@ -242,7 +242,7 @@ namespace ScopeHousingMeshSurgery
             if (renderers != null)
                 _housingRenderers.AddRange(renderers);
 
-            ScopeHousingMeshSurgeryPlugin.LogInfo(
+            PiPDisablerPlugin.LogInfo(
                 $"[Reticle] Housing mask: {_housingRenderers.Count} renderer(s) registered" +
                 $" stencilSupport={_hasStencilSupport}");
         }
@@ -251,7 +251,7 @@ namespace ScopeHousingMeshSurgery
 
         private static void AttachToCamera()
         {
-            var mainCam = ScopeHousingMeshSurgeryPlugin.GetMainCamera();
+            var mainCam = PiPDisablerPlugin.GetMainCamera();
             if (mainCam == null) return;
 
             if (_attachedCamera != null && _attachedCamera != mainCam)
@@ -271,7 +271,7 @@ namespace ScopeHousingMeshSurgery
                 _preCullRegistered = true;
             }
 
-            ScopeHousingMeshSurgeryPlugin.LogInfo(
+            PiPDisablerPlugin.LogInfo(
                 $"[Reticle] CommandBuffer attached to '{mainCam.name}' at AfterForwardAlpha");
         }
 
@@ -403,7 +403,7 @@ namespace ScopeHousingMeshSurgery
                     if (r != null && r.gameObject.activeInHierarchy) activeCount++;
                 }
 
-                ScopeHousingMeshSurgeryPlugin.LogInfo(
+                PiPDisablerPlugin.LogInfo(
                     $"[Reticle] Frame {_debugFrameCount + 1}/{DebugLogFrames}: " +
                     $"useStencil={useStencil} housingTotal={_housingRenderers.Count} " +
                     $"housingActive={activeCount} stencilSupport={_hasStencilSupport}");
@@ -436,7 +436,7 @@ namespace ScopeHousingMeshSurgery
                 // ── Step 4: optional debug overlay — red tint where housing masked ───
                 // Renders anywhere stencil == 1, i.e. every pixel the housing suppressed.
                 // Enable via DebugShowHousingMask in BepInEx config.
-                if (ScopeHousingMeshSurgeryPlugin.GetDebugShowHousingMask()
+                if (PiPDisablerPlugin.GetDebugShowHousingMask()
                     && _stencilDebugMat != null)
                 {
                     _cmdBuffer.DrawMesh(_reticleMesh, fullScreenMatrix, _stencilDebugMat, 0, -1);
@@ -529,7 +529,7 @@ namespace ScopeHousingMeshSurgery
                         Shader.Find("Particles/Additive") ??
                         Shader.Find("Legacy Shaders/Particles/Additive");
 
-                    ScopeHousingMeshSurgeryPlugin.LogWarn(
+                    PiPDisablerPlugin.LogWarn(
                         "[Reticle] No alpha-blend shader found; falling back to Particles/Additive.");
                 }
 
@@ -552,7 +552,7 @@ namespace ScopeHousingMeshSurgery
                     _reticleMat.SetFloat("_StencilWriteMask", 0f);   // don't write
                 }
 
-                ScopeHousingMeshSurgeryPlugin.LogInfo(
+                PiPDisablerPlugin.LogInfo(
                     $"[Reticle] Created material (shader='{(alphaShader != null ? alphaShader.name : "null")}'" +
                     $" stencilSupport={_hasStencilSupport})");
 

--- a/Patches/ScopeDetectionPatches.cs
+++ b/Patches/ScopeDetectionPatches.cs
@@ -5,7 +5,7 @@ using HarmonyLib;
 using SPT.Reflection.Patching;
 using UnityEngine;
 
-namespace ScopeHousingMeshSurgery.Patches
+namespace PiPDisabler.Patches
 {
     internal sealed class OpticSightOnEnablePatch : ModulePatch
     {
@@ -16,11 +16,11 @@ namespace ScopeHousingMeshSurgery.Patches
         private static void Postfix(OpticSight __instance)
         {
             // Always cache the enabled optic (so it's ready if mod is toggled on later)
-            ScopeHousingMeshSurgeryPlugin.LogInfo(
+            PiPDisablerPlugin.LogInfo(
                 $"[Patch] OnEnable: '{(__instance != null ? __instance.name : "null")}' " +
                 $"enabled={__instance?.enabled} frame={Time.frameCount}");
 
-            if (!ScopeHousingMeshSurgeryPlugin.ModEnabled.Value) return;
+            if (!PiPDisablerPlugin.ModEnabled.Value) return;
             ScopeLifecycle.OnOpticEnabled(__instance);
         }
     }
@@ -33,11 +33,11 @@ namespace ScopeHousingMeshSurgery.Patches
         [PatchPostfix]
         private static void Postfix(OpticSight __instance)
         {
-            ScopeHousingMeshSurgeryPlugin.LogInfo(
+            PiPDisablerPlugin.LogInfo(
                 $"[Patch] OnDisable: '{(__instance != null ? __instance.name : "null")}' " +
                 $"frame={Time.frameCount}");
 
-            if (!ScopeHousingMeshSurgeryPlugin.ModEnabled.Value) return;
+            if (!PiPDisablerPlugin.ModEnabled.Value) return;
             ScopeLifecycle.OnOpticDisabled(__instance);
         }
     }
@@ -50,9 +50,9 @@ namespace ScopeHousingMeshSurgery.Patches
         [PatchPostfix]
         private static void Postfix()
         {
-            if (!ScopeHousingMeshSurgeryPlugin.ModEnabled.Value) return;
+            if (!PiPDisablerPlugin.ModEnabled.Value) return;
 
-            ScopeHousingMeshSurgeryPlugin.LogInfo(
+            PiPDisablerPlugin.LogInfo(
                 $"[Patch] ChangeAimingMode frame={Time.frameCount}");
             ScopeLifecycle.CheckAndUpdate("ChangeAimingMode");
         }

--- a/Patches/ScopeDiagnostics.cs
+++ b/Patches/ScopeDiagnostics.cs
@@ -5,7 +5,7 @@ using EFT;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
-namespace ScopeHousingMeshSurgery
+namespace PiPDisabler
 {
     /// <summary>
     /// On-demand diagnostics dump, triggered by DiagnosticsKey.
@@ -81,7 +81,7 @@ namespace ScopeHousingMeshSurgery
             {
                 sb.AppendLine("[Diagnostics] No active OpticSight — not currently scoped.");
                 sb.AppendLine("[Diagnostics] ==========================================");
-                ScopeHousingMeshSurgeryPlugin.LogInfo(sb.ToString());
+                PiPDisablerPlugin.LogInfo(sb.ToString());
                 return;
             }
 
@@ -107,7 +107,7 @@ namespace ScopeHousingMeshSurgery
                 }
                 else
                 {
-                    sb.AppendLine($"[Diagnostics] Magnification   : no ScopeZoomHandler — using DefaultZoom ({ScopeHousingMeshSurgeryPlugin.DefaultZoom.Value:F1}x)");
+                    sb.AppendLine($"[Diagnostics] Magnification   : no ScopeZoomHandler — using DefaultZoom ({PiPDisablerPlugin.DefaultZoom.Value:F1}x)");
                 }
             }
             catch (System.Exception ex)
@@ -117,16 +117,16 @@ namespace ScopeHousingMeshSurgery
 
             // ── Cut plane ─────────────────────────────────────────────────────
             sb.AppendLine("[Diagnostics] --- Cut Plane Config ---");
-            sb.AppendLine($"[Diagnostics]   CutMode          : {ScopeHousingMeshSurgeryPlugin.GetCutMode()}");
-            sb.AppendLine($"[Diagnostics]   PlaneNormalAxis  : {ScopeHousingMeshSurgeryPlugin.GetPlaneNormalAxis()}");
-            sb.AppendLine($"[Diagnostics]   PlaneOffsetMeters: {ScopeHousingMeshSurgeryPlugin.GetPlaneOffsetMeters():F4}");
-            sb.AppendLine($"[Diagnostics]   CylinderRadius   : {ScopeHousingMeshSurgeryPlugin.GetCylinderRadius():F4}");
-            sb.AppendLine($"[Diagnostics]   MidCylinderRadius: {ScopeHousingMeshSurgeryPlugin.GetMidCylinderRadius():F4} @ pos={ScopeHousingMeshSurgeryPlugin.GetMidCylinderPosition():F2}");
-            sb.AppendLine($"[Diagnostics]   FarCylinderRadius: {ScopeHousingMeshSurgeryPlugin.GetFarCylinderRadius():F4}");
-            sb.AppendLine($"[Diagnostics]   CutStartOffset   : {ScopeHousingMeshSurgeryPlugin.GetCutStartOffset():F4}");
-            sb.AppendLine($"[Diagnostics]   CutLength        : {ScopeHousingMeshSurgeryPlugin.GetCutLength():F4}");
-            sb.AppendLine($"[Diagnostics]   NearPreserveDepth: {ScopeHousingMeshSurgeryPlugin.GetNearPreserveDepth():F4}");
-            sb.AppendLine($"[Diagnostics]   CutRadius        : {ScopeHousingMeshSurgeryPlugin.GetCutRadius():F4}");
+            sb.AppendLine($"[Diagnostics]   CutMode          : {PiPDisablerPlugin.GetCutMode()}");
+            sb.AppendLine($"[Diagnostics]   PlaneNormalAxis  : {PiPDisablerPlugin.GetPlaneNormalAxis()}");
+            sb.AppendLine($"[Diagnostics]   PlaneOffsetMeters: {PiPDisablerPlugin.GetPlaneOffsetMeters():F4}");
+            sb.AppendLine($"[Diagnostics]   CylinderRadius   : {PiPDisablerPlugin.GetCylinderRadius():F4}");
+            sb.AppendLine($"[Diagnostics]   MidCylinderRadius: {PiPDisablerPlugin.GetMidCylinderRadius():F4} @ pos={PiPDisablerPlugin.GetMidCylinderPosition():F2}");
+            sb.AppendLine($"[Diagnostics]   FarCylinderRadius: {PiPDisablerPlugin.GetFarCylinderRadius():F4}");
+            sb.AppendLine($"[Diagnostics]   CutStartOffset   : {PiPDisablerPlugin.GetCutStartOffset():F4}");
+            sb.AppendLine($"[Diagnostics]   CutLength        : {PiPDisablerPlugin.GetCutLength():F4}");
+            sb.AppendLine($"[Diagnostics]   NearPreserveDepth: {PiPDisablerPlugin.GetNearPreserveDepth():F4}");
+            sb.AppendLine($"[Diagnostics]   CutRadius        : {PiPDisablerPlugin.GetCutRadius():F4}");
 
             // ── Plane resolution ──────────────────────────────────────────────
             sb.AppendLine("[Diagnostics] --- Plane Resolution ---");
@@ -145,7 +145,7 @@ namespace ScopeHousingMeshSurgery
                 if (ScopeHierarchy.TryGetPlane(os, scopeRoot, activeMode ?? scopeRoot,
                     out var pp, out var pn, out _))
                 {
-                    pp += pn * ScopeHousingMeshSurgeryPlugin.GetPlaneOffsetMeters();
+                    pp += pn * PiPDisablerPlugin.GetPlaneOffsetMeters();
                     sb.AppendLine($"[Diagnostics]   Plane point     : {pp:F4}");
                     sb.AppendLine($"[Diagnostics]   Plane normal    : {pn:F4}");
                 }
@@ -187,11 +187,11 @@ namespace ScopeHousingMeshSurgery
 
             // ── Reticle ───────────────────────────────────────────────────────
             sb.AppendLine("[Diagnostics] --- Reticle ---");
-            sb.AppendLine($"[Diagnostics]   ShowReticle      : {ScopeHousingMeshSurgeryPlugin.GetShowReticle()}");
-            sb.AppendLine($"[Diagnostics]   ReticleBaseSize  : {ScopeHousingMeshSurgeryPlugin.GetReticleBaseSize():F4}");
+            sb.AppendLine($"[Diagnostics]   ShowReticle      : {PiPDisablerPlugin.GetShowReticle()}");
+            sb.AppendLine($"[Diagnostics]   ReticleBaseSize  : {PiPDisablerPlugin.GetReticleBaseSize():F4}");
             sb.AppendLine("[Diagnostics] ==========================================");
 
-            ScopeHousingMeshSurgeryPlugin.LogInfo(sb.ToString());
+            PiPDisablerPlugin.LogInfo(sb.ToString());
         }
 
         private static string GetPath(Transform t)

--- a/Patches/ScopeEffectsRenderer.cs
+++ b/Patches/ScopeEffectsRenderer.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using UnityEngine.Rendering;
 
-namespace ScopeHousingMeshSurgery
+namespace PiPDisabler
 {
     /// <summary>
     /// Renders scope vignette and shadow effects via a CommandBuffer injected at
@@ -64,7 +64,7 @@ namespace ScopeHousingMeshSurgery
             _ = baseSize;
             _ = magnification;
 
-            if (ScopeHousingMeshSurgeryPlugin.VignetteEnabled.Value)
+            if (PiPDisablerPlugin.VignetteEnabled.Value)
             {
                 EnsureVignetteMeshAndMat();
                 RefreshVignetteTexture();
@@ -75,7 +75,7 @@ namespace ScopeHousingMeshSurgery
                 _vigActive = false;
             }
 
-            if (ScopeHousingMeshSurgeryPlugin.ScopeShadowEnabled.Value)
+            if (PiPDisablerPlugin.ScopeShadowEnabled.Value)
             {
                 EnsureShadowMeshAndMat();
                 RefreshShadowTexture();
@@ -90,7 +90,7 @@ namespace ScopeHousingMeshSurgery
 
             AttachToCamera();
 
-            ScopeHousingMeshSurgeryPlugin.LogInfo(
+            PiPDisablerPlugin.LogInfo(
                 $"[ScopeEffects] Showing: vignette={_vigActive} shadow={_shadowActive} (CommandBuffer)");
         }
 
@@ -105,7 +105,7 @@ namespace ScopeHousingMeshSurgery
             if (_shadowActive) RefreshShadowTexture();
 
             // Re-attach if camera changed
-            var mainCam = ScopeHousingMeshSurgeryPlugin.GetMainCamera();
+            var mainCam = PiPDisablerPlugin.GetMainCamera();
             if (mainCam != null && mainCam != _attachedCamera)
                 AttachToCamera();
         }
@@ -133,7 +133,7 @@ namespace ScopeHousingMeshSurgery
 
         private static void AttachToCamera()
         {
-            var mainCam = ScopeHousingMeshSurgeryPlugin.GetMainCamera();
+            var mainCam = PiPDisablerPlugin.GetMainCamera();
             if (mainCam == null) return;
 
             if (_attachedCamera != null && _attachedCamera != mainCam)
@@ -153,7 +153,7 @@ namespace ScopeHousingMeshSurgery
                 _preCullRegistered = true;
             }
 
-            ScopeHousingMeshSurgeryPlugin.LogVerbose(
+            PiPDisablerPlugin.LogVerbose(
                 $"[ScopeEffects] CommandBuffer attached to '{mainCam.name}' at AfterEverything");
         }
 
@@ -289,11 +289,11 @@ namespace ScopeHousingMeshSurgery
         /// </summary>
         private static void RefreshVignetteTexture()
         {
-            float soft = ScopeHousingMeshSurgeryPlugin.VignetteSoftness.Value;
-            float opac = ScopeHousingMeshSurgeryPlugin.VignetteOpacity.Value;
-            float mult = ScopeHousingMeshSurgeryPlugin.VignetteSizeMult.Value;
+            float soft = PiPDisablerPlugin.VignetteSoftness.Value;
+            float opac = PiPDisablerPlugin.VignetteOpacity.Value;
+            float mult = PiPDisablerPlugin.VignetteSizeMult.Value;
 
-            var cam = ScopeHousingMeshSurgeryPlugin.GetMainCamera();
+            var cam = PiPDisablerPlugin.GetMainCamera();
             float aspect = GetDisplayAspect(cam);
 
             if (Mathf.Abs(soft - _lastVigSoftness) < 0.001f &&
@@ -378,11 +378,11 @@ namespace ScopeHousingMeshSurgery
         /// </summary>
         private static void RefreshShadowTexture()
         {
-            float radius = ScopeHousingMeshSurgeryPlugin.ScopeShadowRadius.Value;
-            float soft   = ScopeHousingMeshSurgeryPlugin.ScopeShadowSoftness.Value;
-            float opac   = ScopeHousingMeshSurgeryPlugin.ScopeShadowOpacity.Value;
+            float radius = PiPDisablerPlugin.ScopeShadowRadius.Value;
+            float soft   = PiPDisablerPlugin.ScopeShadowSoftness.Value;
+            float opac   = PiPDisablerPlugin.ScopeShadowOpacity.Value;
 
-            var cam = ScopeHousingMeshSurgeryPlugin.GetMainCamera();
+            var cam = PiPDisablerPlugin.GetMainCamera();
             Rect viewport = GetDisplayViewport(cam);
             int texW = Mathf.Clamp(Mathf.RoundToInt(viewport.width), 64, 4096);
             int texH = Mathf.Clamp(Mathf.RoundToInt(viewport.height), 64, 4096);
@@ -429,7 +429,7 @@ namespace ScopeHousingMeshSurgery
             _shadowTex.Apply();
             if (_shadowMat != null) _shadowMat.mainTexture = _shadowTex;
 
-            ScopeHousingMeshSurgeryPlugin.LogVerbose(
+            PiPDisablerPlugin.LogVerbose(
                 $"[ScopeEffects] Shadow texture rebuilt: {texW}x{texH} aspect={aspect:F2} radius={radius} soft={soft}");
         }
 

--- a/Patches/ScopeLifecycle.cs
+++ b/Patches/ScopeLifecycle.cs
@@ -8,7 +8,7 @@ using Comfort.Common;
 using HarmonyLib;
 using UnityEngine;
 
-namespace ScopeHousingMeshSurgery
+namespace PiPDisabler
 {
     /// <summary>
     /// Event-driven scope lifecycle. State machine with two states: scoped / not scoped.
@@ -151,13 +151,13 @@ namespace ScopeHousingMeshSurgery
                     }
                 }
 
-                ScopeHousingMeshSurgeryPlugin.LogInfo(
+                PiPDisablerPlugin.LogInfo(
                     $"[ScopeLifecycle] Reflection: IsAiming={_isAimingProp != null}, " +
                     $"CurrentScope={_currentScopeProp != null}, IsOptic={_isOpticProp != null}");
             }
             catch (Exception ex)
             {
-                ScopeHousingMeshSurgeryPlugin.LogError($"[ScopeLifecycle] Init failed: {ex.Message}");
+                PiPDisablerPlugin.LogError($"[ScopeLifecycle] Init failed: {ex.Message}");
             }
         }
 
@@ -174,7 +174,7 @@ namespace ScopeHousingMeshSurgery
             // would falsely trigger a restore+recut cycle and cause a 1-2 frame mesh flash.
             if (_isScoped && os != null && os != _activeOptic)
             {
-                ScopeHousingMeshSurgeryPlugin.LogInfo(
+                PiPDisablerPlugin.LogInfo(
                     $"[ScopeLifecycle] Mode switch while scoped: " +
                     $"'{(_activeOptic != null ? _activeOptic.name : "?")}'[{FovController.GetOpticTemplateId(_activeOptic)}] → " +
                     $"'{os.name}'[{FovController.GetOpticTemplateId(os)}]");
@@ -211,7 +211,7 @@ namespace ScopeHousingMeshSurgery
                 FovController.OnModeSwitch();
 
                 // RESTORE all meshes first, then re-cut with new mode's plane position.
-                if (ScopeHousingMeshSurgeryPlugin.EnableMeshSurgery.Value)
+                if (PiPDisablerPlugin.EnableMeshSurgery.Value)
                 {
                     MeshSurgeryManager.RestoreForScope(os.transform);
                     MeshSurgeryManager.ApplyForOptic(os);
@@ -293,7 +293,7 @@ namespace ScopeHousingMeshSurgery
             // Log every state CHANGE (not every frame)
             if (shouldBeScoped != _isScoped)
             {
-                ScopeHousingMeshSurgeryPlugin.LogInfo(
+                PiPDisablerPlugin.LogInfo(
                     $"[ScopeLifecycle] State change: {(_isScoped ? "SCOPED" : "NOT_SCOPED")} → " +
                     $"{(shouldBeScoped ? "SCOPED" : "NOT_SCOPED")} reason='{reason}' " +
                     $"caller={_lastCaller} frame={Time.frameCount}");
@@ -405,14 +405,14 @@ namespace ScopeHousingMeshSurgery
 
             if (os == null)
             {
-                ScopeHousingMeshSurgeryPlugin.LogInfo("[ScopeLifecycle] Whitelist toggle ignored: no active scope");
+                PiPDisablerPlugin.LogInfo("[ScopeLifecycle] Whitelist toggle ignored: no active scope");
                 return;
             }
 
             string scopeName = ResolveWhitelistScopeKey(os);
             if (string.IsNullOrWhiteSpace(scopeName))
             {
-                ScopeHousingMeshSurgeryPlugin.LogWarn(
+                PiPDisablerPlugin.LogWarn(
                     $"[ScopeLifecycle] Whitelist toggle ignored: no usable scope key for '{os.name}'");
                 return;
             }
@@ -431,13 +431,13 @@ namespace ScopeHousingMeshSurgery
                 removed = false;
             }
 
-            ScopeHousingMeshSurgeryPlugin.ScopeWhitelistNames.Value = string.Join(",", _scopeWhitelistNames);
-            _scopeWhitelistRawCached = ScopeHousingMeshSurgeryPlugin.ScopeWhitelistNames.Value ?? string.Empty;
+            PiPDisablerPlugin.ScopeWhitelistNames.Value = string.Join(",", _scopeWhitelistNames);
+            _scopeWhitelistRawCached = PiPDisablerPlugin.ScopeWhitelistNames.Value ?? string.Empty;
 
-            ScopeHousingMeshSurgeryPlugin.LogInfo(
+            PiPDisablerPlugin.LogInfo(
                 $"[ScopeLifecycle] Whitelist {(removed ? "removed" : "added")}: scopeKey='{scopeName}'");
 
-            if (ScopeHousingMeshSurgeryPlugin.ModEnabled.Value && _isScoped)
+            if (PiPDisablerPlugin.ModEnabled.Value && _isScoped)
             {
                 ForceExit();
                 SyncState();
@@ -529,7 +529,7 @@ namespace ScopeHousingMeshSurgery
             if (ShouldBypassByWhitelist(os))
                 return true;
 
-            if (ScopeHousingMeshSurgeryPlugin.AutoDisableForVariableScopes.Value
+            if (PiPDisablerPlugin.AutoDisableForVariableScopes.Value
                 && (FovController.IsOpticAdjustable(os) || IsThermalOrNightVisionOptic(os)))
                 return true;
 
@@ -542,7 +542,7 @@ namespace ScopeHousingMeshSurgery
         private static bool ScopeNameMatchesBypassPattern(OpticSight os)
         {
             if (os == null) return false;
-            string raw = ScopeHousingMeshSurgeryPlugin.AutoBypassNameContains?.Value;
+            string raw = PiPDisablerPlugin.AutoBypassNameContains?.Value;
             if (string.IsNullOrWhiteSpace(raw)) return false;
 
             string scopeKey   = ResolveWhitelistScopeKey(os) ?? string.Empty;
@@ -554,7 +554,7 @@ namespace ScopeHousingMeshSurgery
                 if (string.IsNullOrEmpty(t)) continue;
                 if (ContainsCI(scopeKey, t) || ContainsCI(objectName, t))
                 {
-                    ScopeHousingMeshSurgeryPlugin.LogInfo(
+                    PiPDisablerPlugin.LogInfo(
                         $"[ScopeLifecycle] AutoBypassNameContains match: token='{t}'" +
                         $" objectName='{objectName}' scopeKey='{scopeKey}'");
                     return true;
@@ -576,7 +576,7 @@ namespace ScopeHousingMeshSurgery
 
             if (!allowed)
             {
-                ScopeHousingMeshSurgeryPlugin.LogInfo(
+                PiPDisablerPlugin.LogInfo(
                     $"[ScopeLifecycle] Whitelist bypass: '{os.name}'[scopeKey={scopeName}] is not in ScopeWhitelistNames");
             }
 
@@ -585,7 +585,7 @@ namespace ScopeHousingMeshSurgery
 
         private static void RefreshScopeWhitelistCache()
         {
-            string raw = ScopeHousingMeshSurgeryPlugin.ScopeWhitelistNames.Value ?? string.Empty;
+            string raw = PiPDisablerPlugin.ScopeWhitelistNames.Value ?? string.Empty;
             if (string.Equals(raw, _scopeWhitelistRawCached, StringComparison.Ordinal))
                 return;
 
@@ -644,14 +644,14 @@ namespace ScopeHousingMeshSurgery
 
                 if (hasNightVision || hasThermal)
                 {
-                    ScopeHousingMeshSurgeryPlugin.LogInfo(
+                    PiPDisablerPlugin.LogInfo(
                         $"[ScopeLifecycle] Thermal/NV auto-bypass match: nightVision={hasNightVision} thermal={hasThermal}");
                     return true;
                 }
             }
             catch (Exception ex)
             {
-                ScopeHousingMeshSurgeryPlugin.LogVerbose(
+                PiPDisablerPlugin.LogVerbose(
                     $"[ScopeLifecycle] Thermal/NV detection failed: {ex.Message}");
             }
 
@@ -708,7 +708,7 @@ namespace ScopeHousingMeshSurgery
         private static void ApplyBypassState(OpticSight os, float minFov, string reason)
         {
             string opticName = os != null ? os.name : "null";
-            ScopeHousingMeshSurgeryPlugin.LogInfo(
+            PiPDisablerPlugin.LogInfo(
                 $"[ScopeLifecycle] Bypassing mod for current scope ({reason}): " +
                 $"'{opticName}'[{FovController.GetOpticTemplateId(os)}] " +
                 $"key='{ResolveWhitelistScopeKey(os)}' minFov={minFov:F2}° adjustable={FovController.IsOpticAdjustable(os)}");
@@ -725,7 +725,7 @@ namespace ScopeHousingMeshSurgery
             CameraSettingsManager.Restore();
             PiPDisabler.RestoreAllCameras();
 
-            if (ScopeHousingMeshSurgeryPlugin.GetRestoreOnUnscope())
+            if (PiPDisablerPlugin.GetRestoreOnUnscope())
             {
                 if (os != null)
                     MeshSurgeryManager.RestoreForScope(os.transform);
@@ -745,7 +745,7 @@ namespace ScopeHousingMeshSurgery
                 os = FindOpticFromPWA();
             if (os == null)
             {
-                ScopeHousingMeshSurgeryPlugin.LogVerbose(
+                PiPDisablerPlugin.LogVerbose(
                     "[ScopeLifecycle] ENTER aborted — no OpticSight found");
                 return;
             }
@@ -762,7 +762,7 @@ namespace ScopeHousingMeshSurgery
                 return;
             }
 
-            ScopeHousingMeshSurgeryPlugin.LogInfo(
+            PiPDisablerPlugin.LogInfo(
                 $"[ScopeLifecycle] ENTER: '{os.name}'[{FovController.GetOpticTemplateId(os)}] frame={Time.frameCount}");
 
             // 1. Restore any black lens materials so ExtractReticle can read OpticSight textures.
@@ -787,18 +787,18 @@ namespace ScopeHousingMeshSurgery
 
             // 4b. Show lens vignette + scope shadow effects
             Transform lensT = os.LensRenderer != null ? os.LensRenderer.transform : os.transform;
-            float baseSize = ScopeHousingMeshSurgeryPlugin.GetReticleBaseSize();
-            if (baseSize < 0.001f) baseSize = ScopeHousingMeshSurgeryPlugin.GetCylinderRadius() * 2f;
+            float baseSize = PiPDisablerPlugin.GetReticleBaseSize();
+            if (baseSize < 0.001f) baseSize = PiPDisablerPlugin.GetCylinderRadius() * 2f;
             if (baseSize < 0.001f) baseSize = 0.030f;
             ScopeEffectsRenderer.Show(lensT, baseSize, mag);
 
             // 5. Mesh surgery (once)
-            if (ScopeHousingMeshSurgeryPlugin.EnableMeshSurgery.Value)
+            if (PiPDisablerPlugin.EnableMeshSurgery.Value)
                 MeshSurgeryManager.ApplyForOptic(os);
 
             // 6. Show cut plane visualizer (even without mesh surgery, for debugging)
-            if (ScopeHousingMeshSurgeryPlugin.GetShowCutPlane()
-                && !ScopeHousingMeshSurgeryPlugin.EnableMeshSurgery.Value)
+            if (PiPDisablerPlugin.GetShowCutPlane()
+                && !PiPDisablerPlugin.EnableMeshSurgery.Value)
             {
                 ShowPlaneOnly(os);
             }
@@ -821,7 +821,7 @@ namespace ScopeHousingMeshSurgery
             if (!_isScoped) return;
 
             var prevOptic = _activeOptic;
-            ScopeHousingMeshSurgeryPlugin.LogInfo(
+            PiPDisablerPlugin.LogInfo(
                 $"[ScopeLifecycle] EXIT: '{(prevOptic != null ? prevOptic.name : "null")}'" +
                 $"[{FovController.GetOpticTemplateId(prevOptic)}] frame={Time.frameCount}");
 
@@ -859,7 +859,7 @@ namespace ScopeHousingMeshSurgery
             CameraSettingsManager.Restore();
 
             // 6. Restore meshes
-            if (ScopeHousingMeshSurgeryPlugin.GetRestoreOnUnscope())
+            if (PiPDisablerPlugin.GetRestoreOnUnscope())
             {
                 if (prevOptic != null)
                     MeshSurgeryManager.RestoreForScope(prevOptic.transform);
@@ -896,8 +896,8 @@ namespace ScopeHousingMeshSurgery
         private static List<Renderer> CollectStencilRenderers(OpticSight os)
         {
             var housing = LensTransparency.CollectHousingRenderers(os);
-            if (ScopeHousingMeshSurgeryPlugin.StencilIncludeWeaponMeshes != null
-                && ScopeHousingMeshSurgeryPlugin.StencilIncludeWeaponMeshes.Value)
+            if (PiPDisablerPlugin.StencilIncludeWeaponMeshes != null
+                && PiPDisablerPlugin.StencilIncludeWeaponMeshes.Value)
             {
                 housing.AddRange(LensTransparency.CollectWeaponRenderers(os, housing));
             }
@@ -913,7 +913,7 @@ namespace ScopeHousingMeshSurgery
             try
             {
                 if (_modBypassedForCurrentScope) return;
-                if (!ScopeHousingMeshSurgeryPlugin.EnableZoom.Value) return;
+                if (!PiPDisablerPlugin.EnableZoom.Value) return;
                 if (!CameraClass.Exist) return;
 
                 var player = GetLocalPlayer();
@@ -928,26 +928,26 @@ namespace ScopeHousingMeshSurgery
                 if (zoomedFov >= 0.5f && zoomedFov < zoomBaseFov)
                 {
                     float duration = isTransition
-                        ? ScopeHousingMeshSurgeryPlugin.FovAnimationDuration.Value
+                        ? PiPDisablerPlugin.FovAnimationDuration.Value
                         : 0.1f; // Short duration for variable zoom updates
 
                     CameraClass.Instance.SetFov(zoomedFov, duration, false);
-                    ScopeHousingMeshSurgeryPlugin.LogInfo(
+                    PiPDisablerPlugin.LogInfo(
                         $"[ScopeLifecycle] ApplyFov: {zoomedFov:F1}° dur={duration:F2}s");
                 }
                 else if (isTransition && zoomedFov >= zoomBaseFov)
                 {
                     // High-to-low mode switch where new mode has no zoom:
                     // restore to baseline with configured duration so both directions are consistent
-                    float duration = ScopeHousingMeshSurgeryPlugin.FovAnimationDuration.Value;
+                    float duration = PiPDisablerPlugin.FovAnimationDuration.Value;
                     CameraClass.Instance.SetFov(zoomBaseFov, duration, false);
-                    ScopeHousingMeshSurgeryPlugin.LogInfo(
+                    PiPDisablerPlugin.LogInfo(
                         $"[ScopeLifecycle] ApplyFov (restore baseline): {zoomBaseFov:F1}° dur={duration:F2}s");
                 }
             }
             catch (Exception ex)
             {
-                ScopeHousingMeshSurgeryPlugin.LogVerbose(
+                PiPDisablerPlugin.LogVerbose(
                     $"[ScopeLifecycle] ApplyFov error: {ex.Message}");
             }
         }
@@ -971,16 +971,16 @@ namespace ScopeHousingMeshSurgery
                 float baseFov = pwa.Single_2;
                 if (baseFov > 30f)
                 {
-                float duration = ScopeHousingMeshSurgeryPlugin.FovAnimationDuration.Value;
+                float duration = PiPDisablerPlugin.FovAnimationDuration.Value;
                     cc.SetFov(baseFov, duration, true);
-                    ScopeHousingMeshSurgeryPlugin.LogVerbose(
+                    PiPDisablerPlugin.LogVerbose(
                         $"[ScopeLifecycle] RestoreFov: {baseFov:F1}° dur={duration:F2}s");
 
                 }
             }
             catch (Exception ex)
             {
-                ScopeHousingMeshSurgeryPlugin.LogVerbose(
+                PiPDisablerPlugin.LogVerbose(
                     $"[ScopeLifecycle] RestoreFov error: {ex.Message}");
             }
         }
@@ -1002,7 +1002,7 @@ namespace ScopeHousingMeshSurgery
                     out var planePoint, out var planeNormal, out var camPos))
                     return;
 
-                planePoint += planeNormal * ScopeHousingMeshSurgeryPlugin.GetPlaneOffsetMeters();
+                planePoint += planeNormal * PiPDisablerPlugin.GetPlaneOffsetMeters();
                 PlaneVisualizer.Show(planePoint, planeNormal);
             }
             catch { }

--- a/Patches/WeaponScalingPatch.cs
+++ b/Patches/WeaponScalingPatch.cs
@@ -7,7 +7,7 @@ using HarmonyLib;
 using SPT.Reflection.Patching;
 using UnityEngine;
 
-namespace ScopeHousingMeshSurgery.Patches
+namespace PiPDisabler.Patches
 {
     /// <summary>
     /// Patches Player.SetCompensationScale to override the VISUAL ribcage scale
@@ -59,7 +59,7 @@ namespace ScopeHousingMeshSurgery.Patches
         /// </summary>
         public static void CaptureBaseState()
         {
-            if (!ScopeHousingMeshSurgeryPlugin.EnableWeaponScaling.Value) return;
+            if (!PiPDisablerPlugin.EnableWeaponScaling.Value) return;
             var os = ScopeLifecycle.ActiveOptic;
             if (os == null) { _isActive = false; return; }
             _isActive = true;
@@ -73,7 +73,7 @@ namespace ScopeHousingMeshSurgery.Patches
         public static void UpdateScale()
         {
             if (!_isActive) return;
-            if (!ScopeHousingMeshSurgeryPlugin.EnableWeaponScaling.Value) return;
+            if (!PiPDisablerPlugin.EnableWeaponScaling.Value) return;
 
             try
             {
@@ -113,12 +113,12 @@ namespace ScopeHousingMeshSurgery.Patches
                 player.CalculateScaleValueByFov(settingsFov);
                 player.SetCompensationScale(true);
 
-                ScopeHousingMeshSurgeryPlugin.LogVerbose(
+                PiPDisablerPlugin.LogVerbose(
                     $"[WeaponScaling] Restored normal scaling (settingsFov={settingsFov:F1})");
             }
             catch (Exception ex)
             {
-                ScopeHousingMeshSurgeryPlugin.LogVerbose(
+                PiPDisablerPlugin.LogVerbose(
                     $"[WeaponScaling] RestoreScale error: {ex.Message}");
             }
         }
@@ -133,8 +133,8 @@ namespace ScopeHousingMeshSurgery.Patches
         {
             float halfRefRad = ZoomBaseline * 0.5f * Mathf.Deg2Rad;
             float halfCurRad = currentFov * 0.5f * Mathf.Deg2Rad;
-            float baseline = ScopeHousingMeshSurgeryPlugin.BaselineWeaponScale.Value;
-            float strength = ScopeHousingMeshSurgeryPlugin.WeaponScaleStrength.Value;
+            float baseline = PiPDisablerPlugin.BaselineWeaponScale.Value;
+            float strength = PiPDisablerPlugin.WeaponScaleStrength.Value;
             float tanRef = Mathf.Tan(halfRefRad);
             float tanCur = Mathf.Tan(halfCurRad);
             float invRatio = tanRef / tanCur;
@@ -158,7 +158,7 @@ namespace ScopeHousingMeshSurgery.Patches
             try
             {
                 if (!__instance.IsYourPlayer) return;
-                if (!ScopeHousingMeshSurgeryPlugin.EnableWeaponScaling.Value) return;
+                if (!PiPDisablerPlugin.EnableWeaponScaling.Value) return;
                 if (!ScopeLifecycle.IsScoped) return;
                 if (ScopeLifecycle.IsModBypassedForCurrentScope) return;
                 if (!_isActive) return;

--- a/Patches/ZeroingController.cs
+++ b/Patches/ZeroingController.cs
@@ -9,7 +9,7 @@ using Comfort.Common;
 using HarmonyLib;
 using UnityEngine;
 
-namespace ScopeHousingMeshSurgery
+namespace PiPDisabler
 {
     /// <summary>
     /// Handles optic zeroing (calibration distance) via the proper EFT pathway.
@@ -58,15 +58,15 @@ namespace ScopeHousingMeshSurgery
         /// </summary>
         public static void Tick()
         {
-            if (!ScopeHousingMeshSurgeryPlugin.EnableZeroing.Value) return;
+            if (!PiPDisablerPlugin.EnableZeroing.Value) return;
             if (!ScopeLifecycle.IsScoped) return;
 
             // Cooldown
             if (Time.unscaledTime - _lastZeroingTime < ZEROING_COOLDOWN) return;
 
             // Poll input
-            KeyCode upKey   = ScopeHousingMeshSurgeryPlugin.ZeroingUpKey.Value;
-            KeyCode downKey = ScopeHousingMeshSurgeryPlugin.ZeroingDownKey.Value;
+            KeyCode upKey   = PiPDisablerPlugin.ZeroingUpKey.Value;
+            KeyCode downKey = PiPDisablerPlugin.ZeroingDownKey.Value;
 
             bool wantsUp   = UnityEngine.Input.GetKeyDown(upKey);
             bool wantsDown = UnityEngine.Input.GetKeyDown(downKey);
@@ -92,12 +92,12 @@ namespace ScopeHousingMeshSurgery
                 if (wantsUp)
                 {
                     _opticCalibUpMethod.Invoke(fc, new object[] { scopeStates });
-                    ScopeHousingMeshSurgeryPlugin.LogInfo("[Zeroing] OpticCalibrationSwitchUp called");
+                    PiPDisablerPlugin.LogInfo("[Zeroing] OpticCalibrationSwitchUp called");
                 }
                 else
                 {
                     _opticCalibDownMethod.Invoke(fc, new object[] { scopeStates });
-                    ScopeHousingMeshSurgeryPlugin.LogInfo("[Zeroing] OpticCalibrationSwitchDown called");
+                    PiPDisablerPlugin.LogInfo("[Zeroing] OpticCalibrationSwitchDown called");
                 }
 
                 _lastZeroingTime = Time.unscaledTime;
@@ -107,7 +107,7 @@ namespace ScopeHousingMeshSurgery
             }
             catch (Exception ex)
             {
-                ScopeHousingMeshSurgeryPlugin.LogError($"[Zeroing] Tick failed: {ex.Message}");
+                PiPDisablerPlugin.LogError($"[Zeroing] Tick failed: {ex.Message}");
             }
         }
 
@@ -139,14 +139,14 @@ namespace ScopeHousingMeshSurgery
                     if (meters != CurrentZeroingMeters)
                     {
                         CurrentZeroingMeters = meters;
-                        ScopeHousingMeshSurgeryPlugin.LogInfo(
+                        PiPDisablerPlugin.LogInfo(
                             $"[Zeroing] Current distance: {meters}m");
                     }
                 }
             }
             catch (Exception ex)
             {
-                ScopeHousingMeshSurgeryPlugin.LogVerbose(
+                PiPDisablerPlugin.LogVerbose(
                     $"[Zeroing] ReadCurrentZeroing failed: {ex.Message}");
             }
         }
@@ -225,7 +225,7 @@ namespace ScopeHousingMeshSurgery
 
                 if (_opticCalibUpMethod == null || _opticCalibDownMethod == null)
                 {
-                    ScopeHousingMeshSurgeryPlugin.LogError(
+                    PiPDisablerPlugin.LogError(
                         "[Zeroing] Could not find OpticCalibrationSwitchUp/Down methods");
                     return false;
                 }
@@ -241,7 +241,7 @@ namespace ScopeHousingMeshSurgery
                     if (_scopeStateId == null || _scopeStateScopeIndex == null ||
                         _scopeStateScopeMode == null || _scopeStateCalibIndex == null)
                     {
-                        ScopeHousingMeshSurgeryPlugin.LogWarn(
+                        PiPDisablerPlugin.LogWarn(
                             $"[Zeroing] FirearmScopeStateStruct fields incomplete. " +
                             $"Id={_scopeStateId != null} ScopeIndex={_scopeStateScopeIndex != null} " +
                             $"Mode={_scopeStateScopeMode != null} CalibIdx={_scopeStateCalibIndex != null}. " +
@@ -268,7 +268,7 @@ namespace ScopeHousingMeshSurgery
                         }
                     }
 
-                    ScopeHousingMeshSurgeryPlugin.LogInfo(
+                    PiPDisablerPlugin.LogInfo(
                         $"[Zeroing] Struct type: {_scopeStateStructType.Name} " +
                         $"Id={_scopeStateId?.Name} ScopeIndex={_scopeStateScopeIndex?.Name} " +
                         $"Mode={_scopeStateScopeMode?.Name} CalibIdx={_scopeStateCalibIndex?.Name}");
@@ -285,7 +285,7 @@ namespace ScopeHousingMeshSurgery
                                    _opticCalibDownMethod != null &&
                                    _scopeStateStructType != null;
 
-                ScopeHousingMeshSurgeryPlugin.LogInfo(
+                PiPDisablerPlugin.LogInfo(
                     $"[Zeroing] Reflection ready={_reflectionReady} " +
                     $"Up={_opticCalibUpMethod?.Name} Down={_opticCalibDownMethod?.Name}");
 
@@ -293,7 +293,7 @@ namespace ScopeHousingMeshSurgery
             }
             catch (Exception ex)
             {
-                ScopeHousingMeshSurgeryPlugin.LogError($"[Zeroing] Reflection setup failed: {ex.Message}");
+                PiPDisablerPlugin.LogError($"[Zeroing] Reflection setup failed: {ex.Message}");
                 return false;
             }
         }
@@ -320,7 +320,7 @@ namespace ScopeHousingMeshSurgery
 
                 if (sights.Count == 0)
                 {
-                    ScopeHousingMeshSurgeryPlugin.LogVerbose("[Zeroing] No sights found on weapon");
+                    PiPDisablerPlugin.LogVerbose("[Zeroing] No sights found on weapon");
                     return null;
                 }
 
@@ -344,14 +344,14 @@ namespace ScopeHousingMeshSurgery
                     stateArray.SetValue(state, i);
                 }
 
-                ScopeHousingMeshSurgeryPlugin.LogVerbose(
+                PiPDisablerPlugin.LogVerbose(
                     $"[Zeroing] Built {sights.Count} scope states, aimIndex={currentAimIndex}");
 
                 return stateArray;
             }
             catch (Exception ex)
             {
-                ScopeHousingMeshSurgeryPlugin.LogError($"[Zeroing] BuildScopeStates failed: {ex.Message}");
+                PiPDisablerPlugin.LogError($"[Zeroing] BuildScopeStates failed: {ex.Message}");
                 return null;
             }
         }
@@ -426,7 +426,7 @@ namespace ScopeHousingMeshSurgery
             }
             catch (Exception ex)
             {
-                ScopeHousingMeshSurgeryPlugin.LogError($"[Zeroing] CollectSights failed: {ex.Message}");
+                PiPDisablerPlugin.LogError($"[Zeroing] CollectSights failed: {ex.Message}");
             }
         }
 
@@ -575,7 +575,7 @@ namespace ScopeHousingMeshSurgery
         {
             foreach (var f in fields)
             {
-                ScopeHousingMeshSurgeryPlugin.LogVerbose(
+                PiPDisablerPlugin.LogVerbose(
                     $"[Zeroing] Struct field: {f.Name} type={f.FieldType.Name}");
             }
         }

--- a/Patches/ZoomController.cs
+++ b/Patches/ZoomController.cs
@@ -2,7 +2,7 @@ using System;
 using EFT.CameraControl;
 using UnityEngine;
 
-namespace ScopeHousingMeshSurgery
+namespace PiPDisabler
 {
     /// <summary>
     /// Handles scope zoom math.
@@ -25,7 +25,7 @@ namespace ScopeHousingMeshSurgery
         /// <summary>Kept for API compatibility with existing startup flow.</summary>
         public static void LoadShader()
         {
-            ScopeHousingMeshSurgeryPlugin.LogInfo(
+            PiPDisablerPlugin.LogInfo(
                 "[ZoomController] Using template-based FOV zoom.");
         }
 
@@ -50,7 +50,7 @@ namespace ScopeHousingMeshSurgery
         /// </summary>
         public static float GetMagnification(OpticSight os)
         {
-            if (os == null) return ScopeHousingMeshSurgeryPlugin.DefaultZoom.Value;
+            if (os == null) return PiPDisablerPlugin.DefaultZoom.Value;
 
             // Ensure range is discovered
             if (!_rangeDiscovered)
@@ -70,7 +70,7 @@ namespace ScopeHousingMeshSurgery
         /// </summary>
         public static float GetMinFov(OpticSight os)
         {
-            if (os == null) return 35f / ScopeHousingMeshSurgeryPlugin.DefaultZoom.Value;
+            if (os == null) return 35f / PiPDisablerPlugin.DefaultZoom.Value;
 
             // Try template zoom range first
             var (minZoom, maxZoom) = FovController.GetTemplateZoomRange();
@@ -136,7 +136,7 @@ namespace ScopeHousingMeshSurgery
         /// </summary>
         public static float GetMinMagnification(OpticSight os)
         {
-            if (os == null) return ScopeHousingMeshSurgeryPlugin.DefaultZoom.Value;
+            if (os == null) return PiPDisablerPlugin.DefaultZoom.Value;
 
             var (minZoom, maxZoom) = FovController.GetTemplateZoomRange();
             if (minZoom > 0.1f)
@@ -184,7 +184,7 @@ namespace ScopeHousingMeshSurgery
             {
                 _nativeMinMag = minZoom;
                 _nativeMaxMag = maxZoom;
-                ScopeHousingMeshSurgeryPlugin.LogInfo(
+                PiPDisablerPlugin.LogInfo(
                     $"[ZoomController] Discovered template zoom range: {minZoom:F2}x - {maxZoom:F2}x (variable)");
                 return;
             }
@@ -196,7 +196,7 @@ namespace ScopeHousingMeshSurgery
                 if (szh == null) szh = os.GetComponentInChildren<ScopeZoomHandler>();
                 if (szh == null)
                 {
-                    ScopeHousingMeshSurgeryPlugin.LogVerbose(
+                    PiPDisablerPlugin.LogVerbose(
                         "[ZoomController] No ScopeZoomHandler — fixed scope");
                     return;
                 }
@@ -245,19 +245,19 @@ namespace ScopeHousingMeshSurgery
                     // Convert FOV range to magnification range (35° optic camera baseline)
                     _nativeMinMag = 35f / maxFov; // max FOV → min magnification
                     _nativeMaxMag = 35f / minFov; // min FOV → max magnification
-                        ScopeHousingMeshSurgeryPlugin.LogInfo(
+                        PiPDisablerPlugin.LogInfo(
                         $"[ZoomController] Discovered FOV-based zoom range: " +
                         $"{_nativeMinMag:F2}x - {_nativeMaxMag:F2}x (from FOV {minFov:F2}°-{maxFov:F2}°)");
                 }
                 else
                 {
-                    ScopeHousingMeshSurgeryPlugin.LogVerbose(
+                    PiPDisablerPlugin.LogVerbose(
                         $"[ZoomController] Could not discover zoom range — fixed scope at {currentMag:F2}x");
                 }
             }
             catch (Exception ex)
             {
-                ScopeHousingMeshSurgeryPlugin.LogVerbose(
+                PiPDisablerPlugin.LogVerbose(
                     $"[ZoomController] DiscoverZoomRange exception: {ex.Message}");
             }
         }

--- a/PiPDisablerPlugin.cs
+++ b/PiPDisablerPlugin.cs
@@ -6,6 +6,8 @@ using EFT;
 using EFT.CameraControl;
 using System.IO;
 using UnityEngine;
+using PiPDisabler.Patches;
+
 
 namespace PiPDisabler
 {
@@ -512,7 +514,7 @@ namespace PiPDisabler
             VerboseLogging = Config.Bind("7. Debug", "VerboseLogging", false,
                 "Enable detailed logging. Turn on to diagnose lens/zoom issues.");
 
-            Patches.Patcher.Enable();
+            Patcher.Enable();
 
             // Initialize scope detection via PWA reflection
             ScopeLifecycle.Init();
@@ -533,21 +535,38 @@ namespace PiPDisabler
             Logger.LogInfo($"  EnableMeshSurgery={EnableMeshSurgery.Value}  CutMode={CutMode.Value}  CutLen={CutLength.Value}  NearPreserve={NearPreserveDepth.Value}  ShowReticle={ShowReticle.Value}  ClearMeshCacheOnRaidEnd={ClearMeshCacheOnRaidEnd.Value}");
         }
 
-        private static ScopeMeshSurgerySettingsEntry ActiveScopeOverride => PerScopeMeshSurgerySettings.GetActiveOverride();
+        private static object ActiveScopeOverride => PerScopeMeshSurgerySettings.GetActiveOverride();
 
-        internal static float GetPlaneOffsetMeters() => ActiveScopeOverride != null ? ActiveScopeOverride.PlaneOffsetMeters : PlaneOffsetMeters.Value;
-        internal static string GetPlaneNormalAxis() => ActiveScopeOverride != null ? ActiveScopeOverride.PlaneNormalAxis : PlaneNormalAxis.Value;
-        internal static float GetCutRadius() => ActiveScopeOverride != null ? ActiveScopeOverride.CutRadius : CutRadius.Value;
-        internal static bool GetShowCutPlane() => ActiveScopeOverride != null ? ActiveScopeOverride.ShowCutPlane : ShowCutPlane.Value;
-        internal static bool GetShowCutVolume() => ActiveScopeOverride != null ? ActiveScopeOverride.ShowCutVolume : ShowCutVolume.Value;
-        internal static float GetCutVolumeOpacity() => ActiveScopeOverride != null ? ActiveScopeOverride.CutVolumeOpacity : CutVolumeOpacity.Value;
-        internal static string GetCutMode() => ActiveScopeOverride != null ? ActiveScopeOverride.CutMode : CutMode.Value;
-        internal static float GetCylinderRadius() => ActiveScopeOverride != null ? ActiveScopeOverride.CylinderRadius : CylinderRadius.Value;
-        internal static float GetMidCylinderRadius() => ActiveScopeOverride != null ? ActiveScopeOverride.MidCylinderRadius : MidCylinderRadius.Value;
-        internal static float GetMidCylinderPosition() => ActiveScopeOverride != null ? ActiveScopeOverride.MidCylinderPosition : MidCylinderPosition.Value;
-        internal static float GetFarCylinderRadius() => ActiveScopeOverride != null ? ActiveScopeOverride.FarCylinderRadius : FarCylinderRadius.Value;
-        internal static float GetPlane1OffsetMeters() => ActiveScopeOverride != null ? ActiveScopeOverride.Plane1OffsetMeters : Plane1OffsetMeters.Value;
-        internal static float GetPlane2Position() => ActiveScopeOverride != null ? ActiveScopeOverride.Plane2Position : Plane2Position.Value;
+        private static T GetOverrideOrDefault<T>(string fieldName, ConfigEntry<T> fallback)
+        {
+            object entry = ActiveScopeOverride;
+            if (entry != null)
+            {
+                var field = entry.GetType().GetField(fieldName);
+                if (field != null)
+                {
+                    object value = field.GetValue(entry);
+                    if (value is T typedValue)
+                        return typedValue;
+                }
+            }
+
+            return fallback.Value;
+        }
+
+        internal static float GetPlaneOffsetMeters() => GetOverrideOrDefault("PlaneOffsetMeters", PlaneOffsetMeters);
+        internal static string GetPlaneNormalAxis() => GetOverrideOrDefault("PlaneNormalAxis", PlaneNormalAxis);
+        internal static float GetCutRadius() => GetOverrideOrDefault("CutRadius", CutRadius);
+        internal static bool GetShowCutPlane() => GetOverrideOrDefault("ShowCutPlane", ShowCutPlane);
+        internal static bool GetShowCutVolume() => GetOverrideOrDefault("ShowCutVolume", ShowCutVolume);
+        internal static float GetCutVolumeOpacity() => GetOverrideOrDefault("CutVolumeOpacity", CutVolumeOpacity);
+        internal static string GetCutMode() => GetOverrideOrDefault("CutMode", CutMode);
+        internal static float GetCylinderRadius() => GetOverrideOrDefault("CylinderRadius", CylinderRadius);
+        internal static float GetMidCylinderRadius() => GetOverrideOrDefault("MidCylinderRadius", MidCylinderRadius);
+        internal static float GetMidCylinderPosition() => GetOverrideOrDefault("MidCylinderPosition", MidCylinderPosition);
+        internal static float GetFarCylinderRadius() => GetOverrideOrDefault("FarCylinderRadius", FarCylinderRadius);
+        internal static float GetPlane1OffsetMeters() => GetOverrideOrDefault("Plane1OffsetMeters", Plane1OffsetMeters);
+        internal static float GetPlane2Position() => GetOverrideOrDefault("Plane2Position", Plane2Position);
         internal static float GetPlane2PositionNormalized(float cutLength)
         {
             const float legacyReferenceCutLength = 0.755493f;
@@ -555,19 +574,19 @@ namespace PiPDisabler
             float anchoredDepth = p2LegacyNormalized * legacyReferenceCutLength;
             return cutLength > 1e-5f ? Mathf.Clamp01(anchoredDepth / cutLength) : 0f;
         }
-        internal static float GetPlane2Radius() => ActiveScopeOverride != null ? ActiveScopeOverride.Plane2Radius : Plane2Radius.Value;
-        internal static float GetPlane3Position() => ActiveScopeOverride != null ? ActiveScopeOverride.Plane3Position : Plane3Position.Value;
-        internal static float GetPlane3Radius() => ActiveScopeOverride != null ? ActiveScopeOverride.Plane3Radius : Plane3Radius.Value;
-        internal static float GetPlane4Position() => ActiveScopeOverride != null ? ActiveScopeOverride.Plane4Position : Plane4Position.Value;
-        internal static float GetPlane4Radius() => ActiveScopeOverride != null ? ActiveScopeOverride.Plane4Radius : Plane4Radius.Value;
-        internal static float GetCutStartOffset() => ActiveScopeOverride != null ? ActiveScopeOverride.CutStartOffset : CutStartOffset.Value;
-        internal static float GetCutLength() => ActiveScopeOverride != null ? ActiveScopeOverride.CutLength : CutLength.Value;
-        internal static float GetNearPreserveDepth() => ActiveScopeOverride != null ? ActiveScopeOverride.NearPreserveDepth : NearPreserveDepth.Value;
-        internal static bool GetShowReticle() => ActiveScopeOverride != null ? ActiveScopeOverride.ShowReticle : ShowReticle.Value;
-        internal static float GetReticleBaseSize() => ActiveScopeOverride != null ? ActiveScopeOverride.ReticleBaseSize : ReticleBaseSize.Value;
-        internal static bool GetReticleOverlayCamera() => ActiveScopeOverride != null ? ActiveScopeOverride.ReticleOverlayCamera : ReticleOverlayCamera.Value;
-        internal static bool GetRestoreOnUnscope() => ActiveScopeOverride != null ? ActiveScopeOverride.RestoreOnUnscope : RestoreOnUnscope.Value;
-        internal static bool GetExpandSearchToWeaponRoot() => ActiveScopeOverride != null ? ActiveScopeOverride.ExpandSearchToWeaponRoot : ExpandSearchToWeaponRoot.Value;
+        internal static float GetPlane2Radius() => GetOverrideOrDefault("Plane2Radius", Plane2Radius);
+        internal static float GetPlane3Position() => GetOverrideOrDefault("Plane3Position", Plane3Position);
+        internal static float GetPlane3Radius() => GetOverrideOrDefault("Plane3Radius", Plane3Radius);
+        internal static float GetPlane4Position() => GetOverrideOrDefault("Plane4Position", Plane4Position);
+        internal static float GetPlane4Radius() => GetOverrideOrDefault("Plane4Radius", Plane4Radius);
+        internal static float GetCutStartOffset() => GetOverrideOrDefault("CutStartOffset", CutStartOffset);
+        internal static float GetCutLength() => GetOverrideOrDefault("CutLength", CutLength);
+        internal static float GetNearPreserveDepth() => GetOverrideOrDefault("NearPreserveDepth", NearPreserveDepth);
+        internal static bool GetShowReticle() => GetOverrideOrDefault("ShowReticle", ShowReticle);
+        internal static float GetReticleBaseSize() => GetOverrideOrDefault("ReticleBaseSize", ReticleBaseSize);
+        internal static bool GetReticleOverlayCamera() => GetOverrideOrDefault("ReticleOverlayCamera", ReticleOverlayCamera);
+        internal static bool GetRestoreOnUnscope() => GetOverrideOrDefault("RestoreOnUnscope", RestoreOnUnscope);
+        internal static bool GetExpandSearchToWeaponRoot() => GetOverrideOrDefault("ExpandSearchToWeaponRoot", ExpandSearchToWeaponRoot);
         internal static bool GetDebugShowHousingMask() => DebugShowHousingMask?.Value ?? false;
 
         private void OnDestroy()
@@ -607,11 +626,11 @@ namespace PiPDisabler
         {
             if (!EnableWeaponScaling.Value)
             {
-                Patches.WeaponScalingPatch.RestoreScale();
+                WeaponScalingPatch.RestoreScale();
             }
             else if (ScopeLifecycle.IsScoped)
             {
-                Patches.WeaponScalingPatch.CaptureBaseState();
+                WeaponScalingPatch.CaptureBaseState();
             }
         }
 
@@ -803,3 +822,4 @@ namespace PiPDisabler
 
     }
 }
+


### PR DESCRIPTION
### Motivation
- Rebrand and consolidate the existing ScopeHousingMeshSurgery codebase under a new plugin identity `PiPDisabler` to simplify references and logging.  
- Replace scattered calls to the old plugin accessor with a single `PiPDisablerPlugin` entrypoint to make logging/config access consistent across patches.  
- Provide a safer per-scope override lookup to reduce duplicated code and support per-scope custom settings more robustly.

### Description
- Renamed namespaces and patches from `ScopeHousingMeshSurgery` (and nested `ScopeHousingMeshSurgery.Patches`) to `PiPDisabler` (and `PiPDisabler.Patches`) across all modified files so types and patches align with the new plugin name.  
- Replaced usages of `ScopeHousingMeshSurgeryPlugin.*` with `PiPDisablerPlugin.*` including logging helpers (e.g. `LogInfo`, `LogWarn`, `LogVerbose`) and config accessors across Camera, FOV, LensTransparency, MeshSurgery, Reticle/Effects, Zeroing, ScopeLifecycle, and other systems.  
- Introduced `GetOverrideOrDefault<T>` in `PiPDisablerPlugin` and rewired per-scope config getters to consult the active per-scope override via reflection-safe lookup, replacing many manual conditional expressions.  
- Adjusted patch registration and references (e.g. `Patcher.Enable()` call, patch namespaces, and references to weapon/zoom/mesh utilities) to use the new plugin types and names.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b31a8d114483288a07873ec8ab3b94)