### PR TITLE
Include receiver branch in mesh surgery search root

### DIFF
--- a/Patches/MeshSurgeryManager.cs
+++ b/Patches/MeshSurgeryManager.cs
@@ -327,22 +327,40 @@ namespace ScopeHousingMeshSurgery
 
             var targets = ScopeHierarchy.FindTargetMeshFilters(scopeRoot, activeMode);
             float cutRadius = ScopeHousingMeshSurgeryPlugin.GetCutRadius();
+            bool logCandidates = ScopeHousingMeshSurgeryPlugin.GetDebugLogCutCandidates();
+
+            if (logCandidates)
+            {
+                ScopeHousingMeshSurgeryPlugin.LogInfo(
+                    $"[MeshSurgery][DebugCandidates] scopeRoot='{scopeRoot.name}' activeMode='{activeMode.name}' totalTargets={targets.Count} cutRadius={cutRadius:F4}");
+            }
 
             foreach (var mf in targets)
             {
                 if (!mf || !mf.sharedMesh) continue;
 
-                // Radius filter: skip meshes too far from the cut center.
-                if (cutRadius > 0f)
+                var renderer = mf.GetComponent<Renderer>();
+                var boundsCenter = renderer != null ? renderer.bounds.center : mf.transform.position;
+                float distFromPlane = Vector3.Distance(boundsCenter, planePoint);
+
+                if (logCandidates)
                 {
-                    var boundsCenter = mf.GetComponent<Renderer>()?.bounds.center ?? mf.transform.position;
-                    float dist = Vector3.Distance(boundsCenter, planePoint);
-                    if (dist > cutRadius)
+                    string relPath = ScopeHierarchy.GetRelativePath(mf.transform, scopeRoot);
+                    ScopeHousingMeshSurgeryPlugin.LogInfo(
+                        $"[MeshSurgery][DebugCandidates] target path='{relPath}' go='{mf.gameObject.name}' mesh='{mf.sharedMesh.name}' verts={mf.sharedMesh.vertexCount} active={mf.gameObject.activeInHierarchy} dist={distFromPlane:F4}");
+                }
+
+                // Radius filter: skip meshes too far from the cut center.
+                if (cutRadius > 0f && distFromPlane > cutRadius)
+                {
+                    if (logCandidates)
                     {
-                        ScopeHousingMeshSurgeryPlugin.LogVerbose(
-                            $"[MeshSurgery] Skipping '{mf.sharedMesh.name}' — dist={dist:F4} > radius={cutRadius:F4}");
-                        continue;
+                        ScopeHousingMeshSurgeryPlugin.LogInfo(
+                            $"[MeshSurgery][DebugCandidates] skip radius path='{ScopeHierarchy.GetRelativePath(mf.transform, scopeRoot)}' dist={distFromPlane:F4} > radius={cutRadius:F4}");
                     }
+                    ScopeHousingMeshSurgeryPlugin.LogVerbose(
+                        $"[MeshSurgery] Skipping '{mf.sharedMesh.name}' — dist={distFromPlane:F4} > radius={cutRadius:F4}");
+                    continue;
                 }
 
                 // Already applied? Skip.
@@ -686,6 +704,20 @@ namespace ScopeHousingMeshSurgery
                     stack.Push(t.GetChild(i));
             }
             return null;
+        }
+
+        public static string GetRelativePath(Transform t, Transform root)
+        {
+            if (t == null) return "null";
+
+            var parts = new List<string>();
+            for (var p = t; p != null; p = p.parent)
+            {
+                parts.Add(p.name ?? "unnamed");
+                if (p == root) break;
+            }
+            parts.Reverse();
+            return string.Join("/", parts.ToArray());
         }
 
         public static bool TryGetPlane(OpticSight os, Transform scopeRoot, Transform activeMode,

--- a/Patches/MeshSurgeryManager.cs
+++ b/Patches/MeshSurgeryManager.cs
@@ -818,11 +818,13 @@ namespace ScopeHousingMeshSurgery
             {
                 var pName = p.name ?? "";
                 var plo = pName.ToLowerInvariant();
-                // Stop at weapon root, receiver, or anything that's clearly not scope-related
-                if (plo.Contains("weapon") || plo.Contains("receiver") || plo.Contains("anim"))
+                // Stop at weapon root/anim nodes. We intentionally do NOT stop on
+                // receiver nodes because many attachments (e.g. handguards and tactical
+                // devices) live under the same receiver branch and should be cut too.
+                if (plo.Contains("weapon") || plo.Contains("anim"))
                     break;
-                // Climb through scope/mod/optic/mount containers
-                if (plo.Contains("scope") || plo.Contains("mod_") || plo.Contains("optic") || plo.Contains("mount"))
+                // Climb through scope/mod/optic/mount containers and receiver branches.
+                if (plo.Contains("scope") || plo.Contains("mod_") || plo.Contains("optic") || plo.Contains("mount") || plo.Contains("receiver") || plo.Contains("reciever"))
                 {
                     searchRoot = p;
                     continue; // keep climbing

--- a/PiPDisablerPlugin.cs
+++ b/PiPDisablerPlugin.cs
@@ -181,6 +181,7 @@ namespace PiPDisabler
 
         // --- Debug ---
         internal static ConfigEntry<bool> VerboseLogging;
+        internal static ConfigEntry<bool> DebugLogCutCandidates;
 
         private bool _wasInRaid;
 
@@ -511,6 +512,9 @@ namespace PiPDisabler
             // --- Debug ---
             VerboseLogging = Config.Bind("7. Debug", "VerboseLogging", false,
                 "Enable detailed logging. Turn on to diagnose lens/zoom issues.");
+            DebugLogCutCandidates = Config.Bind("7. Debug", "DebugLogCutCandidates", false,
+                "When enabled, logs every mesh candidate found by mesh surgery (path, mesh name, vertices, active state), " +
+                "plus per-candidate radius checks. Useful to diagnose attachments that are not being cut.");
 
             Patches.Patcher.Enable();
 
@@ -569,6 +573,7 @@ namespace PiPDisabler
         internal static bool GetRestoreOnUnscope() => ActiveScopeOverride != null ? ActiveScopeOverride.RestoreOnUnscope : RestoreOnUnscope.Value;
         internal static bool GetExpandSearchToWeaponRoot() => ActiveScopeOverride != null ? ActiveScopeOverride.ExpandSearchToWeaponRoot : ExpandSearchToWeaponRoot.Value;
         internal static bool GetDebugShowHousingMask() => DebugShowHousingMask?.Value ?? false;
+        internal static bool GetDebugLogCutCandidates() => DebugLogCutCandidates?.Value ?? false;
 
         private void OnDestroy()
         {

--- a/PiPDisablerPlugin.cs
+++ b/PiPDisablerPlugin.cs
@@ -5,6 +5,7 @@ using Comfort.Common;
 using EFT;
 using EFT.CameraControl;
 using System.IO;
+using ScopeHousingMeshSurgery;
 using UnityEngine;
 
 namespace PiPDisabler


### PR DESCRIPTION
### Motivation
- Attachment geometry living under receiver branches (for example M-LOK rails and tactical devices like `Dbal A2`) was not being included in the mesh-cut search root, causing some mounted parts to escape the PiP-disabling mesh surgery.
- The intent is to expand the upward traversal to include receiver branches while still avoiding climbing into full weapon hierarchy unless `ExpandSearchToWeaponRoot` is enabled.

### Description
- Adjusted the parent-climb loop in `ScopeHierarchy.FindTargetMeshFilters` (file `Patches/MeshSurgeryManager.cs`) to no longer break on parents that contain the token `receiver` and to allow climbing into receiver branches.
- Removed `receiver` from the immediate-stop condition and added `receiver` and the common misspelling `reciever` to the allowed climb set, and updated the inline comments to explain the rationale.
- Kept the existing stop conditions for `weapon` and `anim` so traversal still avoids expanding into the full weapon hierarchy by default.

### Testing
- Verified the code diff via `git diff -- Patches/MeshSurgeryManager.cs`, which shows the intended changes to the climb logic and comments.
- Attempted to run a project build with `dotnet build -v minimal`, but the environment lacks the `dotnet` tool so a build could not be executed (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3361d53908328b61011c4c2f0d021)