### PR TITLE
Add debug toggle for reticle CameraEvent (AfterForwardAlpha / AfterEverything)

### DIFF
--- a/Patches/ReticleRenderer.cs
+++ b/Patches/ReticleRenderer.cs
@@ -7,7 +7,8 @@ namespace PiPDisabler
 {
     /// <summary>
     /// Renders the scope reticle via a CommandBuffer injected at
-    /// CameraEvent.AfterForwardAlpha on the main FPS camera.
+    /// a configurable CameraEvent on the main FPS camera
+    /// (AfterForwardAlpha by default, or AfterEverything via debug toggle).
     ///
     /// ── CAMERA ALIGNMENT APPROACH ───────────────────────────────────────
     /// The root cause of reticle jitter is the mismatch between where the
@@ -69,6 +70,7 @@ namespace PiPDisabler
         // CommandBuffer state
         private static CommandBuffer _cmdBuffer;
         private static Camera        _attachedCamera;
+        private static CameraEvent   _attachedCameraEvent = CameraEvent.AfterForwardAlpha;
         private static bool          _preCullRegistered;
 
         // World-space TRS for the reticle quad (rebuilt in onPreCull)
@@ -254,16 +256,27 @@ namespace PiPDisabler
             var mainCam = PiPDisablerPlugin.GetMainCamera();
             if (mainCam == null) return;
 
+            CameraEvent desiredEvent = PiPDisablerPlugin.GetReticleCameraEvent();
+
+            if (_attachedCamera == mainCam && _cmdBuffer != null && _attachedCameraEvent == desiredEvent)
+                return;
+
             if (_attachedCamera != null && _attachedCamera != mainCam)
                 DetachFromCamera();
 
-            if (_attachedCamera == mainCam) return;
+            if (_attachedCamera != null && _cmdBuffer != null && _attachedCameraEvent != desiredEvent)
+            {
+                try { _attachedCamera.RemoveCommandBuffer(_attachedCameraEvent, _cmdBuffer); }
+                catch (System.Exception) { }
+                _attachedCamera = null;
+            }
 
             if (_cmdBuffer == null)
                 _cmdBuffer = new CommandBuffer { name = "ScopeReticleOverlay" };
 
-            mainCam.AddCommandBuffer(CameraEvent.AfterForwardAlpha, _cmdBuffer);
+            mainCam.AddCommandBuffer(desiredEvent, _cmdBuffer);
             _attachedCamera = mainCam;
+            _attachedCameraEvent = desiredEvent;
 
             if (!_preCullRegistered)
             {
@@ -272,7 +285,7 @@ namespace PiPDisabler
             }
 
             PiPDisablerPlugin.LogInfo(
-                $"[Reticle] CommandBuffer attached to '{mainCam.name}' at AfterForwardAlpha");
+                $"[Reticle] CommandBuffer attached to '{mainCam.name}' at {_attachedCameraEvent}");
         }
 
         private static void DetachFromCamera()
@@ -285,7 +298,7 @@ namespace PiPDisabler
 
             if (_attachedCamera != null && _cmdBuffer != null)
             {
-                try { _attachedCamera.RemoveCommandBuffer(CameraEvent.AfterForwardAlpha, _cmdBuffer); }
+                try { _attachedCamera.RemoveCommandBuffer(_attachedCameraEvent, _cmdBuffer); }
                 catch (System.Exception) { }
             }
 

--- a/PiPDisablerPlugin.cs
+++ b/PiPDisablerPlugin.cs
@@ -183,6 +183,7 @@ namespace PiPDisabler
         // --- Debug ---
         internal static ConfigEntry<bool> VerboseLogging;
         internal static ConfigEntry<bool> DebugLogCutCandidates;
+        internal static ConfigEntry<bool> DebugReticleAfterEverything;
 
         private bool _wasInRaid;
 
@@ -516,6 +517,9 @@ namespace PiPDisabler
             DebugLogCutCandidates = Config.Bind("7. Debug", "DebugLogCutCandidates", false,
                 "When enabled, logs every mesh candidate found by mesh surgery (path, mesh name, vertices, active state), " +
                 "plus per-candidate radius checks. Useful to diagnose attachments that are not being cut.");
+            DebugReticleAfterEverything = Config.Bind("7. Debug", "DebugReticleAfterEverything", false,
+                "DEBUG: Draw reticle at CameraEvent.AfterEverything instead of AfterForwardAlpha. " +
+                "Use for render-order diagnostics (e.g. if post-processing or masks are affecting the reticle unexpectedly).");
 
             Patches.Patcher.Enable();
 
@@ -575,6 +579,9 @@ namespace PiPDisabler
         internal static bool GetExpandSearchToWeaponRoot() => ActiveScopeOverride != null ? ActiveScopeOverride.ExpandSearchToWeaponRoot : ExpandSearchToWeaponRoot.Value;
         internal static bool GetDebugShowHousingMask() => DebugShowHousingMask?.Value ?? false;
         internal static bool GetDebugLogCutCandidates() => DebugLogCutCandidates?.Value ?? false;
+        internal static CameraEvent GetReticleCameraEvent() => (DebugReticleAfterEverything?.Value ?? false)
+            ? CameraEvent.AfterEverything
+            : CameraEvent.AfterForwardAlpha;
 
         private void OnDestroy()
         {


### PR DESCRIPTION
### Motivation

- Provide a simple debug switch to change when the reticle quad is drawn relative to Unity's render pipeline so render-order issues (postprocessing, NVG, masks) can be diagnosed.

### Description

- Added a new debug config entry `DebugReticleAfterEverything` under `7. Debug` and a helper `GetReticleCameraEvent()` in `PiPDisablerPlugin.cs` to select the `CameraEvent` (`AfterForwardAlpha` by default, `AfterEverything` when enabled).
- Updated `Patches/ReticleRenderer.cs` to track the attached `CameraEvent` via `_attachedCameraEvent`, attach the `CommandBuffer` using the configured event, rebind safely if the event changes at runtime, and include the active event in attach logging.
- Changes touch `PiPDisablerPlugin.cs` and `Patches/ReticleRenderer.cs` and preserve existing stencil/reticle logic while making the injection point configurable for debugging.

### Testing

- Attempted to build with `dotnet build -v minimal`, but the command failed in this environment because `dotnet` is not installed (`bash: command not found: dotnet`).
- Verified source changes with `git diff`, `git status`, and committed the changes (`git commit`) which succeeded; current HEAD short id is shown in the branch.
- No automated Unity/C# runtime tests were run due to missing build/runtime toolchain in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b34c694aa88328b5f10534abf7496b)