### PR TITLE
Add debug toggle to choose reticle CommandBuffer event (AfterForwardAlpha / AfterEverything)

### DIFF
--- a/Patches/ReticleRenderer.cs
+++ b/Patches/ReticleRenderer.cs
@@ -69,6 +69,7 @@ namespace PiPDisabler
         // CommandBuffer state
         private static CommandBuffer _cmdBuffer;
         private static Camera        _attachedCamera;
+        private static CameraEvent   _attachedEvent = CameraEvent.AfterForwardAlpha;
         private static bool          _preCullRegistered;
 
         // World-space TRS for the reticle quad (rebuilt in onPreCull)
@@ -183,6 +184,8 @@ namespace PiPDisabler
         {
             if (_cmdBuffer == null) return;
 
+            EnsureCorrectCameraEvent();
+
             if (magnification < 1f) magnification = 1f;
             if (Mathf.Abs(magnification - _lastMag) >= 0.01f)
                 _lastMag = magnification;
@@ -262,8 +265,10 @@ namespace PiPDisabler
             if (_cmdBuffer == null)
                 _cmdBuffer = new CommandBuffer { name = "ScopeReticleOverlay" };
 
-            mainCam.AddCommandBuffer(CameraEvent.AfterForwardAlpha, _cmdBuffer);
+            CameraEvent targetEvent = GetReticleCameraEvent();
+            mainCam.AddCommandBuffer(targetEvent, _cmdBuffer);
             _attachedCamera = mainCam;
+            _attachedEvent = targetEvent;
 
             if (!_preCullRegistered)
             {
@@ -272,7 +277,7 @@ namespace PiPDisabler
             }
 
             PiPDisablerPlugin.LogInfo(
-                $"[Reticle] CommandBuffer attached to '{mainCam.name}' at AfterForwardAlpha");
+                $"[Reticle] CommandBuffer attached to '{mainCam.name}' at {_attachedEvent}");
         }
 
         private static void DetachFromCamera()
@@ -285,7 +290,7 @@ namespace PiPDisabler
 
             if (_attachedCamera != null && _cmdBuffer != null)
             {
-                try { _attachedCamera.RemoveCommandBuffer(CameraEvent.AfterForwardAlpha, _cmdBuffer); }
+                try { _attachedCamera.RemoveCommandBuffer(_attachedEvent, _cmdBuffer); }
                 catch (System.Exception) { }
             }
 
@@ -297,6 +302,30 @@ namespace PiPDisabler
             }
 
             _attachedCamera = null;
+        }
+
+
+        private static CameraEvent GetReticleCameraEvent()
+        {
+            return PiPDisablerPlugin.GetDebugReticleAfterEverything()
+                ? CameraEvent.AfterEverything
+                : CameraEvent.AfterForwardAlpha;
+        }
+
+        private static void EnsureCorrectCameraEvent()
+        {
+            if (_attachedCamera == null || _cmdBuffer == null) return;
+
+            CameraEvent desiredEvent = GetReticleCameraEvent();
+            if (desiredEvent == _attachedEvent) return;
+
+            try { _attachedCamera.RemoveCommandBuffer(_attachedEvent, _cmdBuffer); }
+            catch (System.Exception) { }
+
+            _attachedCamera.AddCommandBuffer(desiredEvent, _cmdBuffer);
+            _attachedEvent = desiredEvent;
+
+            PiPDisablerPlugin.LogInfo($"[Reticle] CommandBuffer moved to {_attachedEvent} (debug toggle)");
         }
 
         // ── onPreCull — camera alignment + rebuild CommandBuffer ─────────────

--- a/Patches/ReticleRenderer.cs
+++ b/Patches/ReticleRenderer.cs
@@ -387,7 +387,7 @@ namespace PiPDisabler
             ndcSize = Mathf.Clamp(ndcSize, 0.01f, 2f);
 
             Vector3 pos = new Vector3(0f, 0f, 0.5f);
-            float aspect = GetSceneAspect(cam);
+            float aspect = GetActiveAspect(cam);
             Vector3 scale = new Vector3(ndcSize / Mathf.Max(0.01f, aspect), ndcSize, 1f);
             _reticleMatrix = Matrix4x4.TRS(pos, Quaternion.identity, scale);
         }
@@ -405,19 +405,28 @@ namespace PiPDisabler
         /// Falls back to the original single-draw path when stencil is unavailable or no
         /// housing renderers have been registered.
         ///
-        /// Note: SetRenderTarget is intentionally absent.  At AfterForwardAlpha the active
-        /// RT is already the scene colour buffer.  Explicitly binding CameraTarget resolves
-        /// to the wrong surface under DLSS/FSR and silently drops all draws.
+        /// Note: when attached at AfterForwardAlpha we do NOT rebind the render target,
+        /// because the active RT is already the scene colour buffer.  When attached at
+        /// AfterEverything (debug mode), we explicitly bind CameraTarget + display viewport
+        /// so clip-space quads map to the final upscaled frame.
         /// </summary>
         private static void RebuildCommandBuffer(Camera cam)
         {
             _cmdBuffer.Clear();
 
-            // SetViewport uses the camera's render-resolution pixel dimensions.
-            // Do NOT use Screen.width/height here — under DLSS/FSR the camera renders
-            // at a lower internal resolution and Screen reports the display resolution,
-            // which would pin the viewport offset and mis-center the reticle.
-            _cmdBuffer.SetViewport(GetSceneViewport(cam));
+            bool isAfterEverything = _attachedEvent == CameraEvent.AfterEverything;
+
+            if (isAfterEverything)
+            {
+                // Late-overlay path: draw in display space after upscaling/postfx.
+                _cmdBuffer.SetRenderTarget(BuiltinRenderTextureType.CameraTarget);
+                _cmdBuffer.SetViewport(GetDisplayViewport(cam));
+            }
+            else
+            {
+                // Scene-overlay path: use render-resolution viewport for DLSS/FSR correctness.
+                _cmdBuffer.SetViewport(GetSceneViewport(cam));
+            }
 
             bool useStencil = _hasStencilSupport && _housingRenderers.Count > 0
                               && _stencilClearMat != null && _housingStencilMat != null;
@@ -496,11 +505,33 @@ namespace PiPDisabler
         }
 
         /// <summary>
-        /// Returns the aspect ratio of the scene render target.
-        /// Used to compensate the reticle quad's X scale so it stays square.
+        /// Returns the display viewport in pixels.
+        /// Used by the AfterEverything debug path where overlays are drawn to the
+        /// final display-sized camera target rather than the internal scene RT.
         /// </summary>
-        private static float GetSceneAspect(Camera cam)
+        private static Rect GetDisplayViewport(Camera cam)
         {
+            float w = Mathf.Max(1f, Screen.width);
+            float h = Mathf.Max(1f, Screen.height);
+            if (cam != null)
+            {
+                w = Mathf.Max(w, cam.pixelWidth);
+                h = Mathf.Max(h, cam.pixelHeight);
+            }
+            return new Rect(0f, 0f, w, h);
+        }
+
+        /// <summary>
+        /// Returns the aspect ratio for the currently attached command-buffer event.
+        /// </summary>
+        private static float GetActiveAspect(Camera cam)
+        {
+            if (_attachedEvent == CameraEvent.AfterEverything)
+            {
+                Rect r = GetDisplayViewport(cam);
+                return Mathf.Max(0.01f, r.width / Mathf.Max(1f, r.height));
+            }
+
             return Mathf.Max(0.01f, cam.pixelWidth / Mathf.Max(1f, cam.pixelHeight));
         }
 

--- a/PiPDisablerPlugin.cs
+++ b/PiPDisablerPlugin.cs
@@ -183,6 +183,7 @@ namespace PiPDisabler
         // --- Debug ---
         internal static ConfigEntry<bool> VerboseLogging;
         internal static ConfigEntry<bool> DebugLogCutCandidates;
+        internal static ConfigEntry<bool> DebugReticleAfterEverything;
 
         private bool _wasInRaid;
 
@@ -516,6 +517,9 @@ namespace PiPDisabler
             DebugLogCutCandidates = Config.Bind("7. Debug", "DebugLogCutCandidates", false,
                 "When enabled, logs every mesh candidate found by mesh surgery (path, mesh name, vertices, active state), " +
                 "plus per-candidate radius checks. Useful to diagnose attachments that are not being cut.");
+            DebugReticleAfterEverything = Config.Bind("7. Debug", "DebugReticleAfterEverything", false,
+                "Debug toggle for reticle CommandBuffer event. False = AfterForwardAlpha (default, NVG-friendly). " +
+                "True = AfterEverything (late overlay testing). ");
 
             Patches.Patcher.Enable();
 
@@ -575,6 +579,7 @@ namespace PiPDisabler
         internal static bool GetExpandSearchToWeaponRoot() => ActiveScopeOverride != null ? ActiveScopeOverride.ExpandSearchToWeaponRoot : ExpandSearchToWeaponRoot.Value;
         internal static bool GetDebugShowHousingMask() => DebugShowHousingMask?.Value ?? false;
         internal static bool GetDebugLogCutCandidates() => DebugLogCutCandidates?.Value ?? false;
+        internal static bool GetDebugReticleAfterEverything() => DebugReticleAfterEverything?.Value ?? false;
 
         private void OnDestroy()
         {


### PR DESCRIPTION
### Motivation
- Provide a small debug switch to test reticle overlay timing by moving the reticle CommandBuffer between `CameraEvent.AfterForwardAlpha` (default, NVG-friendly) and `CameraEvent.AfterEverything` (late overlay testing).

### Description
- Added a new debug config entry `DebugReticleAfterEverything` in the `7. Debug` section and exposed it via `GetDebugReticleAfterEverything()` so runtime code can query the setting.
- Updated `ReticleRenderer` to track the attached `CameraEvent` (`_attachedEvent`) and to attach the CommandBuffer using the selected event via `GetReticleCameraEvent()`.
- Implemented `EnsureCorrectCameraEvent()` to migrate an existing CommandBuffer between events at runtime when the debug toggle changes, and updated attach/detach logic to use the tracked event.
- Improved logging to include the active camera event when attaching/moving the CommandBuffer.

### Testing
- Attempted to run a project build with `dotnet build`, but the `dotnet` CLI is not available in this environment so the build could not be executed (failure).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b34f8e91d8832894ace4a25c84f1bb)