### PR TITLE
Add NVG-aware auto-switch for reticle render event (with debug override)

### DIFF
--- a/Patches/ReticleRenderer.cs
+++ b/Patches/ReticleRenderer.cs
@@ -307,9 +307,17 @@ namespace PiPDisabler
 
         private static CameraEvent GetReticleCameraEvent()
         {
-            return PiPDisablerPlugin.GetDebugReticleAfterEverything()
-                ? CameraEvent.AfterEverything
-                : CameraEvent.AfterForwardAlpha;
+            if (PiPDisablerPlugin.GetDebugReticleAfterEverything())
+                return CameraEvent.AfterEverything;
+
+            if (!PiPDisablerPlugin.GetAutoSwitchReticleRenderForNvg())
+                return CameraEvent.AfterForwardAlpha;
+
+            // EFT's NightVision effect writes this global as 1 while NVG are active.
+            // NVG ON: draw at AfterForwardAlpha so post-fx includes the reticle.
+            // NVG OFF: draw at AfterEverything for crisp final-overlay output.
+            bool nvgOn = Shader.GetGlobalFloat("_NightVisionOn") > 0.5f;
+            return nvgOn ? CameraEvent.AfterForwardAlpha : CameraEvent.AfterEverything;
         }
 
         private static void EnsureCorrectCameraEvent()

--- a/PiPDisablerPlugin.cs
+++ b/PiPDisablerPlugin.cs
@@ -72,6 +72,7 @@ namespace PiPDisabler
         // --- 0. Global ---
         internal static ConfigEntry<bool> ModEnabled;
         internal static ConfigEntry<KeyCode> ModToggleKey;
+        internal static ConfigEntry<bool> AutoSwitchReticleRenderForNvg;
 
         // --- General ---
         internal static ConfigEntry<bool> DisablePiP;
@@ -197,6 +198,10 @@ namespace PiPDisabler
                 "cleaned up and the game behaves as if the mod is not installed.");
             ModToggleKey = Config.Bind("0. Global", "ModToggleKey", KeyCode.Backspace,
                 "Toggle key for master mod enable/disable.");
+            AutoSwitchReticleRenderForNvg = Config.Bind("0. Global", "AutoSwitchReticleRenderForNvg", false,
+                "Automatically switch reticle CommandBuffer event based on NVG state.\n" +
+                "ON: use AfterForwardAlpha while NVG are active and AfterEverything otherwise.\n" +
+                "OFF: keep the normal path (AfterForwardAlpha) unless debug override is enabled.");
 
             // --- General ---
             DisablePiP = Config.Bind("1. General", "DisablePiP", true,
@@ -580,6 +585,7 @@ namespace PiPDisabler
         internal static bool GetDebugShowHousingMask() => DebugShowHousingMask?.Value ?? false;
         internal static bool GetDebugLogCutCandidates() => DebugLogCutCandidates?.Value ?? false;
         internal static bool GetDebugReticleAfterEverything() => DebugReticleAfterEverything?.Value ?? false;
+        internal static bool GetAutoSwitchReticleRenderForNvg() => AutoSwitchReticleRenderForNvg?.Value ?? false;
 
         private void OnDestroy()
         {


### PR DESCRIPTION
### Motivation
- Add a global option to automatically choose the reticle `CommandBuffer` event based on NVG state so the reticle renders under `AfterForwardAlpha` when NVG are active and `AfterEverything` otherwise, while preserving the existing debug override.

### Description
- Added a new config entry `AutoSwitchReticleRenderForNvg` under `0. Global` and descriptive help text in `PiPDisablerPlugin.cs`.
- Exposed a safe accessor `GetAutoSwitchReticleRenderForNvg()` so other code can read the setting.
- Modified `ReticleRenderer.GetReticleCameraEvent()` to enforce debug precedence (`DebugReticleAfterEverything` always wins), return the normal `AfterForwardAlpha` path when auto-switch is disabled, and otherwise detect NVG state from the global shader flag `_NightVisionOn` to choose `AfterForwardAlpha` when NVG is on and `AfterEverything` when NVG is off.
- Files changed: `PiPDisablerPlugin.cs`, `Patches/ReticleRenderer.cs`.

### Testing
- Attempted to build with `dotnet build PiPDisabler.csproj -nologo` to validate compilation, but the environment lacks the `dotnet` SDK so the build could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3543c6e508328b3cf3faff490dbd8)