### PR TITLE
Fix bypassed scope enter FOV behavior

### DIFF
--- a/Patches/ScopeLifecycle.cs
+++ b/Patches/ScopeLifecycle.cs
@@ -707,6 +707,7 @@ namespace PiPDisabler
 
         private static void ApplyBypassState(OpticSight os, float minFov, string reason)
         {
+            bool isScopeEnter = string.Equals(reason, "scope enter", StringComparison.OrdinalIgnoreCase);
             string opticName = os != null ? os.name : "null";
             PiPDisablerPlugin.LogInfo(
                 $"[ScopeLifecycle] Bypassing mod for current scope ({reason}): " +
@@ -715,7 +716,11 @@ namespace PiPDisabler
 
             // Ensure this path behaves like a full unscope cleanup so non-whitelisted
             // optics are truly vanilla while still staying in ADS.
-            RestoreFov();
+            // On fresh scope-enter we should not force a restore-to-base FOV because it can
+            // suppress the game's own vanilla zoom-in for bypassed optics until another mode
+            // change kicks a new SetFov path.
+            if (!isScopeEnter)
+                RestoreFov();
             Patches.WeaponScalingPatch.RestoreScale();
             ZoomController.Restore();
             ZoomController.ResetScrollZoom();


### PR DESCRIPTION
### Motivation
- Bypassed optics that were auto-bypassed on scope enter were preventing the game's vanilla zoom-in from applying until a later magnification/mode change, causing a delayed or missing FOV zoom effect.

### Description
- Modify `Patches/ScopeLifecycle.cs` so `ApplyBypassState` checks the bypass `reason` and avoids calling `RestoreFov()` when `reason` equals `"scope enter"`, preserving the game's initial vanilla zoom-in for bypassed scopes.

### Testing
- Attempted `dotnet build -v minimal`, but the build could not be run in this environment because the `dotnet` command is not available (build failed due to missing runtime).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3f20a17f483289e24214e3ebadfc5)