### PR TITLE
Fix vanilla FOV zoom delay for bypassed scopes

### DIFF
--- a/Patches/ScopeLifecycle.cs
+++ b/Patches/ScopeLifecycle.cs
@@ -187,7 +187,7 @@ namespace PiPDisabler
                 if (bypassForMode)
                 {
                     _modBypassedForCurrentScope = true;
-                    ApplyBypassState(os, minFov, reason: "mode switch");
+                    ApplyBypassState(os, minFov, reason: "mode switch", restoreFov: true);
                     return;
                 }
 
@@ -705,7 +705,7 @@ namespace PiPDisabler
 
         // ===== State transitions =====
 
-        private static void ApplyBypassState(OpticSight os, float minFov, string reason)
+        private static void ApplyBypassState(OpticSight os, float minFov, string reason, bool restoreFov)
         {
             string opticName = os != null ? os.name : "null";
             PiPDisablerPlugin.LogInfo(
@@ -715,7 +715,11 @@ namespace PiPDisabler
 
             // Ensure this path behaves like a full unscope cleanup so non-whitelisted
             // optics are truly vanilla while still staying in ADS.
-            RestoreFov();
+            // On fresh scope enter, forcing RestoreFov() can stomp EFT's own optic zoom
+            // for bypassed scopes until the next zoom/mode event. Let vanilla drive FOV
+            // immediately on enter, but still restore when switching from a modded mode.
+            if (restoreFov)
+                RestoreFov();
             Patches.WeaponScalingPatch.RestoreScale();
             ZoomController.Restore();
             ZoomController.ResetScrollZoom();
@@ -758,7 +762,7 @@ namespace PiPDisabler
             _modBypassedForCurrentScope = ShouldBypassForCurrentOptic(os, minFov);
             if (_modBypassedForCurrentScope)
             {
-                ApplyBypassState(os, minFov, reason: "scope enter");
+                ApplyBypassState(os, minFov, reason: "scope enter", restoreFov: false);
                 return;
             }
 


### PR DESCRIPTION
### Motivation
- Bypassed optics were forcing a mod restore path that called `RestoreFov()` on scope enter, which suppressed the game's vanilla optic zoom until a subsequent magnification/mode event occurred.
- The change ensures vanilla FOV behavior applies immediately for whitelisted/bypassed scopes while preserving correct restore behavior during mode switches.

### Description
- Added a `restoreFov` flag to `ApplyBypassState(OpticSight, float, string, bool)` and made the `RestoreFov()` call conditional on it.
- Updated the mode-switch bypass call to `ApplyBypassState(..., restoreFov: true)` so restores still occur when transitioning from a modded mode to a bypassed mode.
- Updated the fresh scope-enter bypass call to `ApplyBypassState(..., restoreFov: false)` to avoid stomping EFT's own optic zoom on enter.
- Added explanatory comments documenting why forcing `RestoreFov()` on enter caused delayed vanilla zoom behavior.

### Testing
- Attempted an automated build with `dotnet build -c Release`, but it failed because the environment lacks the `dotnet` CLI (`command not found`).
- Verified the change was committed to `Patches/ScopeLifecycle.cs` and the modified call sites are present as intended (manual inspection via version control commands).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3fc35b0f883288dc2f71c4abbc549)