### PR TITLE
Add per-frame mesh-cut budget and defer scope-enter until cutting completes

### DIFF
--- a/Patches/MeshSurgeryManager.cs
+++ b/Patches/MeshSurgeryManager.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.IO;
 using System.Security.Cryptography;
 using System.Text;
+using System.Diagnostics;
 using EFT.CameraControl;
 using UnityEngine;
 
@@ -46,6 +47,24 @@ namespace PiPDisabler
         private static readonly Dictionary<GameObject, SphereState> _disabledWeaponSpheres =
             new Dictionary<GameObject, SphereState>(32);
         private static bool _loggedGpuCopy;
+        private sealed class ApplyContext
+        {
+            public Transform ScopeRoot;
+            public Transform ActiveMode;
+            public Vector3 PlanePoint;
+            public Vector3 PlaneNormal;
+            public MeshPlaneCutter.KeepSide KeepSide;
+            public bool IsCylinderMode;
+            public float Plane1Offset;
+            public float CutRadius;
+            public bool LogCandidates;
+            public List<MeshFilter> Targets;
+            public int NextTargetIndex;
+            public int TotalProcessed;
+        }
+
+        private static ApplyContext _pendingApply;
+        public static bool IsApplyInProgress => _pendingApply != null;
 
         public static void ClearPersistentCache()
         {
@@ -338,7 +357,6 @@ namespace PiPDisabler
             PiPDisablerPlugin.LogVerbose(
                 $"[MeshSurgery] Plane: point={planePoint:F4} normal={planeNormal:F4} keepSide={keepSide}");
 
-            // Show visualizer (if enabled)
             PlaneVisualizer.Show(planePoint, planeNormal);
 
             var targets = ScopeHierarchy.FindTargetMeshFilters(scopeRoot, activeMode);
@@ -354,45 +372,74 @@ namespace PiPDisabler
             DisableLightEffectMeshesForScope(scopeRoot, logCandidates);
             DisableWeaponSphereObjects(scopeRoot, logCandidates);
 
-            foreach (var mf in targets)
+            _pendingApply = new ApplyContext
             {
+                ScopeRoot = scopeRoot,
+                ActiveMode = activeMode,
+                PlanePoint = planePoint,
+                PlaneNormal = planeNormal,
+                KeepSide = keepSide,
+                IsCylinderMode = isCylinderMode,
+                Plane1Offset = plane1Offset,
+                CutRadius = cutRadius,
+                LogCandidates = logCandidates,
+                Targets = targets,
+                NextTargetIndex = 0,
+                TotalProcessed = 0
+            };
+
+            TickApplyWork();
+        }
+
+        public static void TickApplyWork()
+        {
+            var ctx = _pendingApply;
+            if (ctx == null) return;
+
+            float budgetMs = PiPDisablerPlugin.GetMeshCutWorkBudgetMs();
+            if (budgetMs <= 0f) budgetMs = 0.1f;
+
+            var sw = Stopwatch.StartNew();
+
+            while (ctx.NextTargetIndex < ctx.Targets.Count)
+            {
+                var mf = ctx.Targets[ctx.NextTargetIndex++];
+                ctx.TotalProcessed++;
+
                 if (!mf || !mf.sharedMesh) continue;
 
                 var renderer = mf.GetComponent<Renderer>();
                 var boundsCenter = renderer != null ? renderer.bounds.center : mf.transform.position;
-                float distFromPlane = Vector3.Distance(boundsCenter, planePoint);
+                float distFromPlane = Vector3.Distance(boundsCenter, ctx.PlanePoint);
 
-                if (logCandidates)
+                if (ctx.LogCandidates)
                 {
-                    string relPath = ScopeHierarchy.GetRelativePath(mf.transform, scopeRoot);
+                    string relPath = ScopeHierarchy.GetRelativePath(mf.transform, ctx.ScopeRoot);
                     PiPDisablerPlugin.LogInfo(
                         $"[MeshSurgery][DebugCandidates] target path='{relPath}' go='{mf.gameObject.name}' mesh='{mf.sharedMesh.name}' verts={mf.sharedMesh.vertexCount} active={mf.gameObject.activeInHierarchy} dist={distFromPlane:F4}");
                 }
 
-                // Radius filter: skip meshes too far from the cut center.
-                if (cutRadius > 0f && distFromPlane > cutRadius)
+                if (ctx.CutRadius > 0f && distFromPlane > ctx.CutRadius)
                 {
-                    if (logCandidates)
+                    if (ctx.LogCandidates)
                     {
                         PiPDisablerPlugin.LogInfo(
-                            $"[MeshSurgery][DebugCandidates] skip radius path='{ScopeHierarchy.GetRelativePath(mf.transform, scopeRoot)}' dist={distFromPlane:F4} > radius={cutRadius:F4}");
+                            $"[MeshSurgery][DebugCandidates] skip radius path='{ScopeHierarchy.GetRelativePath(mf.transform, ctx.ScopeRoot)}' dist={distFromPlane:F4} > radius={ctx.CutRadius:F4}");
                     }
                     PiPDisablerPlugin.LogVerbose(
-                        $"[MeshSurgery] Skipping '{mf.sharedMesh.name}' — dist={distFromPlane:F4} > radius={cutRadius:F4}");
+                        $"[MeshSurgery] Skipping '{mf.sharedMesh.name}' — dist={distFromPlane:F4} > radius={ctx.CutRadius:F4}");
                     continue;
                 }
 
-                // Already applied? Skip.
                 if (_tracked.TryGetValue(mf, out var existing) && existing.Applied)
                     continue;
 
-                // First time: save original and create cut mesh.
                 Mesh originalAsset = mf.sharedMesh;
 
                 try
                 {
-                    bool isCylinder = PiPDisablerPlugin.GetCutMode() == "Cylinder";
-                    string cacheKey = MeshCutCache.BuildKey(scopeRoot, activeMode, mf, originalAsset, keepSide, isCylinder);
+                    bool isCylinder = ctx.IsCylinderMode;
+                    string cacheKey = MeshCutCache.BuildKey(ctx.ScopeRoot, ctx.ActiveMode, mf, originalAsset, ctx.KeepSide, isCylinder);
 
                     Mesh readable;
                     if (MeshCutCache.TryLoad(cacheKey, out var cachedMesh))
@@ -404,7 +451,6 @@ namespace PiPDisabler
                     }
                     else
                     {
-                        // Step 1: GPU copy to create a readable mesh
                         readable = MeshPlaneCutter.MakeReadableMeshCopy(originalAsset);
                         if (readable == null)
                         {
@@ -423,8 +469,6 @@ namespace PiPDisabler
                         }
 
                         int vertsBefore = readable.vertexCount;
-
-                        // Step 2: Cut the readable mesh in-place
                         bool ok;
 
                         if (isCylinder)
@@ -441,25 +485,24 @@ namespace PiPDisabler
                             float r4 = PiPDisablerPlugin.GetPlane4Radius();
 
                             ok = MeshPlaneCutter.CutMeshFrustum(readable, mf.transform,
-                                planePoint, planeNormal, nearR, r4, startOff, cutLen,
+                                ctx.PlanePoint, ctx.PlaneNormal, nearR, r4, startOff, cutLen,
                                 keepInside: false, midRadius: r2, midPosition: p2,
                                 nearPreserveDepth: preserve,
                                 plane3Radius: r3, plane3Position: p3, plane4Position: p4);
                             PiPDisablerPlugin.LogVerbose(
                                 $"[MeshSurgery] Frustum cut '{originalAsset.name}': p1R={nearR:F4}@0.00 " +
                                 $"p2R={r2:F4}@{p2:F2} p3R={r3:F4}@{p3:F2} p4R={r4:F4}@{p4:F2} " +
-                                $"start={startOff:F4} len={cutLen:F4} offset={plane1Offset:F4}" +
+                                $"start={startOff:F4} len={cutLen:F4} offset={ctx.Plane1Offset:F4}" +
                                 (preserve > 0f ? $" preserve={preserve:F4}" : ""));
                         }
                         else
                         {
                             ok = MeshPlaneCutter.CutMeshDirect(readable, mf.transform,
-                                planePoint, planeNormal, keepSide);
+                                ctx.PlanePoint, ctx.PlaneNormal, ctx.KeepSide);
                         }
 
                         if (!ok)
                         {
-                            // Cut removed everything — clear the mesh to make it empty
                             readable.Clear();
                             readable.name = originalAsset.name + "_CUT_EMPTY";
                             PiPDisablerPlugin.LogVerbose(
@@ -476,10 +519,8 @@ namespace PiPDisabler
                         MeshCutCache.Save(cacheKey, readable);
                     }
 
-                    // Step 3: Swap onto the MeshFilter
                     mf.sharedMesh = readable;
 
-                    // Step 4: Track for restore
                     _tracked[mf] = new MeshState
                     {
                         OriginalAssetMesh = originalAsset,
@@ -492,9 +533,18 @@ namespace PiPDisabler
                     PiPDisablerPlugin.LogError(
                         $"[MeshSurgery] Failed on '{originalAsset.name}': {ex.Message}");
                 }
+
+                if (sw.Elapsed.TotalMilliseconds >= budgetMs)
+                    break;
+            }
+
+            if (ctx.NextTargetIndex >= ctx.Targets.Count)
+            {
+                PiPDisablerPlugin.LogVerbose(
+                    $"[MeshSurgery] Apply complete: processed {ctx.TotalProcessed}/{ctx.Targets.Count} targets.");
+                _pendingApply = null;
             }
         }
-
         private static Transform FindWeaponTransform(Transform scopeRoot)
         {
             for (var p = scopeRoot; p != null; p = p.parent)
@@ -626,6 +676,7 @@ namespace PiPDisabler
 
         public static void RestoreForScope(Transform anyTransformUnderScope)
         {
+            _pendingApply = null;
             var scopeRoot = ScopeHierarchy.FindScopeRoot(anyTransformUnderScope);
             if (!scopeRoot) return;
 
@@ -681,6 +732,7 @@ namespace PiPDisabler
 
         public static void RestoreAll()
         {
+            _pendingApply = null;
             var keys = _tracked.Keys.ToArray();
             var lightKeys = _disabledLightFx.Keys.ToArray();
             var sphereKeys = _disabledWeaponSpheres.Keys.ToArray();

--- a/Patches/ScopeLifecycle.cs
+++ b/Patches/ScopeLifecycle.cs
@@ -43,6 +43,7 @@ namespace PiPDisabler
         private static OpticSight _activeOptic;
         private static OpticSight _lastEnabledOptic; // cache from OnEnable
         private static bool _modBypassedForCurrentScope;
+        private static bool _scopeEnterFinalizePending;
 
         // Thermal/NV discovery cache (ScopeData component shape is stable at runtime)
         private static Type _scopeDataType;
@@ -320,6 +321,16 @@ namespace PiPDisabler
         {
             if (!_isScoped) return;
             if (_modBypassedForCurrentScope) return;
+
+            MeshSurgeryManager.TickApplyWork();
+            if (_scopeEnterFinalizePending)
+            {
+                if (MeshSurgeryManager.IsApplyInProgress)
+                    return;
+
+                FinalizeScopeEnter();
+                _scopeEnterFinalizePending = false;
+            }
 
             // Ensure lens stays hidden + update variable zoom
             if (ZoomController.IsActive)
@@ -800,23 +811,31 @@ namespace PiPDisabler
             if (PiPDisablerPlugin.EnableMeshSurgery.Value)
                 MeshSurgeryManager.ApplyForOptic(os);
 
-            // 6. Show cut plane visualizer (even without mesh surgery, for debugging)
+            // Defer the rest of scope-enter until mesh surgery work queue is done.
+            if (MeshSurgeryManager.IsApplyInProgress)
+            {
+                _scopeEnterFinalizePending = true;
+                return;
+            }
+
+            FinalizeScopeEnter();
+        }
+
+        private static void FinalizeScopeEnter()
+        {
+            var os = _activeOptic;
+            if (os == null) return;
+
+            // Show cut plane visualizer (even without mesh surgery, for debugging)
             if (PiPDisablerPlugin.GetShowCutPlane()
                 && !PiPDisablerPlugin.EnableMeshSurgery.Value)
             {
                 ShowPlaneOnly(os);
             }
 
-            // 7. Swap main camera LOD/culling settings with scope camera settings
             CameraSettingsManager.ApplyForOptic(os);
-
-            // 8. Capture weapon base scale/FOV BEFORE changing FOV (for weapon scaling compensation)
             Patches.WeaponScalingPatch.CaptureBaseState();
-
-            // 9. Apply animated FOV zoom (uses FovAnimationDuration)
             ApplyFov(true);
-
-            // 10. Read initial zeroing distance
             ZeroingController.ReadCurrentZeroing();
         }
 
@@ -831,6 +850,7 @@ namespace PiPDisabler
 
             _isScoped = false;
             _activeOptic = null;
+            _scopeEnterFinalizePending = false;
             PerScopeMeshSurgerySettings.ClearActiveScope();
 
             // If this scope was bypassed, skip mod cleanup paths.

--- a/PiPDisablerPlugin.cs
+++ b/PiPDisablerPlugin.cs
@@ -91,6 +91,7 @@ namespace PiPDisabler
         internal static ConfigEntry<KeyCode> MeshSurgeryToggleKey;
         internal static ConfigEntry<bool> RestoreOnUnscope;
         internal static ConfigEntry<bool> ClearMeshCacheOnRaidEnd;
+        internal static ConfigEntry<float> MeshCutWorkBudgetMs;
         internal static ConfigEntry<float> PlaneOffsetMeters;
         internal static ConfigEntry<string> PlaneNormalAxis;
         internal static ConfigEntry<float> CutRadius;
@@ -324,6 +325,11 @@ namespace PiPDisabler
                 "Restore original meshes when leaving scope.");
             ClearMeshCacheOnRaidEnd = Config.Bind("3. Global Mesh Surgery settings", "ClearMeshCacheOnRaidEnd", true,
                 "Clear persisted mesh-cut cache files when transitioning from raid to out-of-raid.");
+            MeshCutWorkBudgetMs = Config.Bind("3. Global Mesh Surgery settings", "MeshCutWorkBudgetMs", 2.5f,
+                new ConfigDescription(
+                    "Per-frame mesh cutting budget in milliseconds.\n" +
+                    "Lower values reduce frame spikes but spread mesh surgery across more frames.",
+                    new AcceptableValueRange<float>(0.1f, 33f)));
             PlaneOffsetMeters = Config.Bind("3. Global Mesh Surgery settings", "PlaneOffsetMeters", 0.001f,
                 "Offset applied along plane normal (meters).");
             PlaneNormalAxis = Config.Bind("3. Global Mesh Surgery settings", "PlaneNormalAxis", "-Y",
@@ -566,6 +572,7 @@ namespace PiPDisabler
         internal static float GetPlaneOffsetMeters() => ActiveScopeOverride != null ? ActiveScopeOverride.PlaneOffsetMeters : PlaneOffsetMeters.Value;
         internal static string GetPlaneNormalAxis() => ActiveScopeOverride != null ? ActiveScopeOverride.PlaneNormalAxis : PlaneNormalAxis.Value;
         internal static float GetCutRadius() => ActiveScopeOverride != null ? ActiveScopeOverride.CutRadius : CutRadius.Value;
+        internal static float GetMeshCutWorkBudgetMs() => MeshCutWorkBudgetMs != null ? MeshCutWorkBudgetMs.Value : 2.5f;
         internal static bool GetShowCutPlane() => ActiveScopeOverride != null ? ActiveScopeOverride.ShowCutPlane : ShowCutPlane.Value;
         internal static bool GetShowCutVolume() => ActiveScopeOverride != null ? ActiveScopeOverride.ShowCutVolume : ShowCutVolume.Value;
         internal static float GetCutVolumeOpacity() => ActiveScopeOverride != null ? ActiveScopeOverride.CutVolumeOpacity : CutVolumeOpacity.Value;


### PR DESCRIPTION
### Motivation
- Mesh surgery could cause frame hitches when many target meshes are processed in one frame, so mesh cutting work should be throttled per-frame. 
- Scope enter performed many dependent actions immediately after scheduling mesh cuts, which could run before cutting finished and lead to visual glitches; finalization should wait until cutting completes.

### Description
- Added a configurable per-frame budget `MeshCutWorkBudgetMs` with accessor `GetMeshCutWorkBudgetMs()` in `PiPDisablerPlugin.cs` to control mesh-cut workload per frame.
- Refactored `MeshSurgeryManager.ApplyForOptic` into a queued `ApplyContext` flow and introduced `_pendingApply` + `IsApplyInProgress` so cuts are processed incrementally. The new `TickApplyWork()` processes targets up to the configured millisecond budget and resumes on subsequent frames (`Patches/MeshSurgeryManager.cs`).
- Deferred the remainder of scope-enter work until mesh cutting completes by adding `_scopeEnterFinalizePending`, calling `MeshSurgeryManager.TickApplyWork()` in `ScopeLifecycle.Tick()`, and moving camera/FOV/zeroing steps into a new `FinalizeScopeEnter()` method invoked after cutting finishes (`Patches/ScopeLifecycle.cs`).
- Cancelled any in-flight pending apply when restoring meshes or restoring all to avoid stale queued jobs by clearing `_pendingApply` in `RestoreForScope` and `RestoreAll` (`Patches/MeshSurgeryManager.cs`).

### Testing
- Attempted to compile with `dotnet build` but it failed in this environment with `dotnet: command not found`, so no compile/test run was possible here (failure).
- Repository changes were staged and committed locally (commit succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b414c143c083289d9409700263268a)