### PR TITLE
Include player hand meshes in mesh surgery target selection

### DIFF
--- a/Patches/MeshSurgeryManager.cs
+++ b/Patches/MeshSurgeryManager.cs
@@ -17,6 +17,7 @@ namespace PiPDisabler
         private sealed class CutMeshEntry
         {
             public MeshFilter Filter;
+            public SkinnedMeshRenderer SkinnedRenderer;
             public Mesh OriginalMesh;
             public Mesh CutMesh;
             public bool Applied;
@@ -218,13 +219,13 @@ namespace PiPDisabler
                 }
             }
 
-            public static string BuildKey(Transform scopeRoot, Transform activeMode, MeshFilter mf, Mesh originalAsset, MeshPlaneCutter.KeepSide keepSide, bool isCylinder)
+            public static string BuildKey(Transform scopeRoot, Transform activeMode, Transform targetTransform, Mesh originalAsset, MeshPlaneCutter.KeepSide keepSide, bool isCylinder)
             {
                 var sb = new StringBuilder(512);
                 sb.Append("v3|");
                 sb.Append(scopeRoot != null ? scopeRoot.name : "scope").Append('|');
                 sb.Append(activeMode != null ? activeMode.name : "mode").Append('|');
-                sb.Append(GetRelativePath(scopeRoot, mf != null ? mf.transform : null)).Append('|');
+                sb.Append(GetRelativePath(scopeRoot, targetTransform)).Append('|');
                 sb.Append(originalAsset != null ? originalAsset.name : "null").Append('|');
                 sb.Append(originalAsset != null ? originalAsset.vertexCount : 0).Append('|');
                 sb.Append(originalAsset != null ? originalAsset.subMeshCount : 0).Append('|');
@@ -467,29 +468,29 @@ namespace PiPDisabler
             cache.Entries.Clear();
 
             var targets = ScopeHierarchy.FindTargetMeshFilters(scopeRoot, activeMode);
+            var handSkinnedTargets = ScopeHierarchy.FindPlayerHandSkinnedMeshRenderers(scopeRoot);
             float cutRadius = PiPDisablerPlugin.GetCutRadius();
             bool logCandidates = PiPDisablerPlugin.GetDebugLogCutCandidates();
 
             DisableLightEffectMeshesForScope(scopeRoot, logCandidates);
             DisableWeaponSphereObjects(scopeRoot, logCandidates);
 
-            foreach (var mf in targets)
+            void ProcessTarget(Transform targetTransform, Renderer renderer, Mesh originalAsset,
+                Action<Mesh> assignMesh, MeshFilter mf = null, SkinnedMeshRenderer smr = null)
             {
-                if (!mf || !mf.sharedMesh) continue;
+                if (targetTransform == null || originalAsset == null || assignMesh == null)
+                    return;
 
-                var renderer = mf.GetComponent<Renderer>();
-                var boundsCenter = renderer != null ? renderer.bounds.center : mf.transform.position;
+                var boundsCenter = renderer != null ? renderer.bounds.center : targetTransform.position;
                 float distFromPlane = Vector3.Distance(boundsCenter, planePoint);
 
                 if (cutRadius > 0f && distFromPlane > cutRadius)
-                    continue;
-
-                Mesh originalAsset = mf.sharedMesh;
+                    return;
 
                 try
                 {
                     bool isCylinder = PiPDisablerPlugin.GetCutMode() == "Cylinder";
-                    string cacheKey = MeshCutCache.BuildKey(scopeRoot, activeMode, mf, originalAsset, keepSide, isCylinder);
+                    string cacheKey = MeshCutCache.BuildKey(scopeRoot, activeMode, targetTransform, originalAsset, keepSide, isCylinder);
 
                     Mesh readable;
                     if (MeshCutCache.TryLoad(cacheKey, out var cachedMesh))
@@ -501,7 +502,7 @@ namespace PiPDisabler
                     {
                         readable = MeshPlaneCutter.MakeReadableMeshCopy(originalAsset);
                         if (readable == null)
-                            continue;
+                            return;
 
                         if (!_loggedGpuCopy)
                         {
@@ -525,7 +526,7 @@ namespace PiPDisabler
                             float p4 = PiPDisablerPlugin.GetPlane4Position();
                             float r4 = PiPDisablerPlugin.GetPlane4Radius();
 
-                            ok = MeshPlaneCutter.CutMeshFrustum(readable, mf.transform,
+                            ok = MeshPlaneCutter.CutMeshFrustum(readable, targetTransform,
                                 planePoint, planeNormal, nearR, r4, startOff, cutLen,
                                 keepInside: false, midRadius: r2, midPosition: p2,
                                 nearPreserveDepth: preserve,
@@ -533,7 +534,7 @@ namespace PiPDisabler
                         }
                         else
                         {
-                            ok = MeshPlaneCutter.CutMeshDirect(readable, mf.transform,
+                            ok = MeshPlaneCutter.CutMeshDirect(readable, targetTransform,
                                 planePoint, planeNormal, keepSide);
                         }
 
@@ -553,10 +554,11 @@ namespace PiPDisabler
                         MeshCutCache.Save(cacheKey, readable);
                     }
 
-                    mf.sharedMesh = readable;
+                    assignMesh(readable);
                     cache.Entries.Add(new CutMeshEntry
                     {
                         Filter = mf,
+                        SkinnedRenderer = smr,
                         OriginalMesh = originalAsset,
                         CutMesh = readable,
                         Applied = true
@@ -567,6 +569,20 @@ namespace PiPDisabler
                     PiPDisablerPlugin.LogError(
                         $"[MeshSurgery] Failed on '{originalAsset.name}': {ex.Message}");
                 }
+            }
+
+            foreach (var mf in targets)
+            {
+                if (!mf || !mf.sharedMesh) continue;
+                ProcessTarget(mf.transform, mf.GetComponent<Renderer>(), mf.sharedMesh,
+                    mesh => mf.sharedMesh = mesh, mf: mf);
+            }
+
+            foreach (var smr in handSkinnedTargets)
+            {
+                if (!smr || !smr.sharedMesh) continue;
+                ProcessTarget(smr.transform, smr, smr.sharedMesh,
+                    mesh => smr.sharedMesh = mesh, smr: smr);
             }
 
             cache.Built = true;
@@ -582,10 +598,16 @@ namespace PiPDisabler
 
             foreach (var entry in cache.Entries)
             {
-                if (entry == null || entry.Filter == null || entry.CutMesh == null)
+                if (entry == null || entry.CutMesh == null)
                     continue;
 
-                entry.Filter.sharedMesh = entry.CutMesh;
+                if (entry.Filter != null)
+                    entry.Filter.sharedMesh = entry.CutMesh;
+                else if (entry.SkinnedRenderer != null)
+                    entry.SkinnedRenderer.sharedMesh = entry.CutMesh;
+                else
+                    continue;
+
                 entry.Applied = true;
             }
         }
@@ -596,14 +618,19 @@ namespace PiPDisabler
 
             foreach (var entry in cache.Entries)
             {
-                if (entry == null || entry.Filter == null)
+                if (entry == null)
                     continue;
 
                 if (!entry.Applied)
                     continue;
 
                 if (entry.OriginalMesh != null)
-                    entry.Filter.sharedMesh = entry.OriginalMesh;
+                {
+                    if (entry.Filter != null)
+                        entry.Filter.sharedMesh = entry.OriginalMesh;
+                    else if (entry.SkinnedRenderer != null)
+                        entry.SkinnedRenderer.sharedMesh = entry.OriginalMesh;
+                }
 
                 entry.Applied = false;
             }
@@ -1408,6 +1435,31 @@ namespace PiPDisabler
                 PiPDisablerPlugin.LogVerbose(
                     $"[ScopeHierarchy] Added {added} player hand mesh(es) from '{playerMeshRoot.name}' to mesh surgery targets.");
             }
+        }
+
+        public static List<SkinnedMeshRenderer> FindPlayerHandSkinnedMeshRenderers(Transform scopeRoot)
+        {
+            var result = new List<SkinnedMeshRenderer>(8);
+            if (scopeRoot == null)
+                return result;
+
+            Transform playerMeshRoot = FindChildByPath(scopeRoot.root, "Player/Mesh");
+            if (playerMeshRoot == null)
+                return result;
+
+            foreach (var smr in playerMeshRoot.GetComponentsInChildren<SkinnedMeshRenderer>(true))
+            {
+                if (!smr || !smr.sharedMesh)
+                    continue;
+
+                string path = GetRelativePath(smr.transform, playerMeshRoot);
+                if (!ContainsHandKeyword(path) && !ContainsHandKeyword(smr.gameObject.name))
+                    continue;
+
+                result.Add(smr);
+            }
+
+            return result;
         }
 
         private static bool ContainsHandKeyword(string value)

--- a/Patches/MeshSurgeryManager.cs
+++ b/Patches/MeshSurgeryManager.cs
@@ -1403,37 +1403,38 @@ namespace PiPDisabler
             if (scopeRoot == null || result == null || seen == null)
                 return;
 
-            Transform playerMeshRoot = FindChildByPath(scopeRoot.root, "Player/Mesh");
-            if (playerMeshRoot == null)
-                return;
-
+            var playerMeshRoots = FindPlayerMeshRoots(scopeRoot, logCandidates);
             int added = 0;
-            foreach (var mf in playerMeshRoot.GetComponentsInChildren<MeshFilter>(true))
+
+            foreach (var playerMeshRoot in playerMeshRoots)
             {
-                if (!mf || !mf.sharedMesh)
-                    continue;
-
-                string path = GetRelativePath(mf.transform, playerMeshRoot);
-                if (!ContainsHandKeyword(path) && !ContainsHandKeyword(mf.gameObject.name))
-                    continue;
-
-                if (!seen.Add(mf.GetInstanceID()))
-                    continue;
-
-                result.Add(mf);
-                added++;
-
-                if (logCandidates)
+                foreach (var mf in playerMeshRoot.GetComponentsInChildren<MeshFilter>(true))
                 {
-                    PiPDisablerPlugin.LogInfo(
-                        $"[MeshSurgery][DebugCandidates] added-player-hand path='Player/Mesh/{path}' go='{mf.gameObject.name}' mesh='{mf.sharedMesh.name}' verts={mf.sharedMesh.vertexCount} active={mf.gameObject.activeInHierarchy}");
+                    if (!mf || !mf.sharedMesh)
+                        continue;
+
+                    string path = GetRelativePath(mf.transform, playerMeshRoot);
+                    if (!ContainsHandKeyword(path) && !ContainsHandKeyword(mf.gameObject.name))
+                        continue;
+
+                    if (!seen.Add(mf.GetInstanceID()))
+                        continue;
+
+                    result.Add(mf);
+                    added++;
+
+                    if (logCandidates)
+                    {
+                        PiPDisablerPlugin.LogInfo(
+                            $"[MeshSurgery][DebugCandidates] added-player-hand path='{GetRelativePath(mf.transform, scopeRoot.root)}' go='{mf.gameObject.name}' mesh='{mf.sharedMesh.name}' verts={mf.sharedMesh.vertexCount} active={mf.gameObject.activeInHierarchy}");
+                    }
                 }
             }
 
             if (added > 0)
             {
                 PiPDisablerPlugin.LogVerbose(
-                    $"[ScopeHierarchy] Added {added} player hand mesh(es) from '{playerMeshRoot.name}' to mesh surgery targets.");
+                    $"[ScopeHierarchy] Added {added} player hand mesh(es) to mesh surgery targets.");
             }
         }
 
@@ -1443,23 +1444,83 @@ namespace PiPDisabler
             if (scopeRoot == null)
                 return result;
 
-            Transform playerMeshRoot = FindChildByPath(scopeRoot.root, "Player/Mesh");
-            if (playerMeshRoot == null)
-                return result;
-
-            foreach (var smr in playerMeshRoot.GetComponentsInChildren<SkinnedMeshRenderer>(true))
+            var seen = new HashSet<int>();
+            var playerMeshRoots = FindPlayerMeshRoots(scopeRoot, logCandidates: false);
+            foreach (var playerMeshRoot in playerMeshRoots)
             {
-                if (!smr || !smr.sharedMesh)
-                    continue;
+                foreach (var smr in playerMeshRoot.GetComponentsInChildren<SkinnedMeshRenderer>(true))
+                {
+                    if (!smr || !smr.sharedMesh)
+                        continue;
 
-                string path = GetRelativePath(smr.transform, playerMeshRoot);
-                if (!ContainsHandKeyword(path) && !ContainsHandKeyword(smr.gameObject.name))
-                    continue;
+                    string path = GetRelativePath(smr.transform, playerMeshRoot);
+                    if (!ContainsHandKeyword(path) && !ContainsHandKeyword(smr.gameObject.name))
+                        continue;
 
-                result.Add(smr);
+                    if (seen.Add(smr.GetInstanceID()))
+                        result.Add(smr);
+                }
             }
 
             return result;
+        }
+
+        private static List<Transform> FindPlayerMeshRoots(Transform scopeRoot, bool logCandidates)
+        {
+            var results = new List<Transform>(4);
+            var seen = new HashSet<int>();
+
+            void AddRoot(Transform candidate)
+            {
+                if (candidate == null)
+                    return;
+                if (seen.Add(candidate.GetInstanceID()))
+                    results.Add(candidate);
+            }
+
+            AddRoot(FindChildByPath(scopeRoot != null ? scopeRoot.root : null, "Player/Mesh"));
+
+            try
+            {
+                foreach (var t in Resources.FindObjectsOfTypeAll<Transform>())
+                {
+                    if (!t) continue;
+
+                    var parent = t.parent;
+                    var grandParent = parent != null ? parent.parent : null;
+                    if (parent == null || grandParent == null)
+                        continue;
+
+                    if (!string.Equals(t.name, "Mesh", StringComparison.OrdinalIgnoreCase))
+                        continue;
+                    if (!string.Equals(parent.name, "Player", StringComparison.OrdinalIgnoreCase))
+                        continue;
+
+                    string gp = grandParent.name ?? string.Empty;
+                    if (gp.IndexOf("PlayerSuperior", StringComparison.OrdinalIgnoreCase) >= 0)
+                        AddRoot(t);
+                }
+            }
+            catch (Exception ex)
+            {
+                PiPDisablerPlugin.LogVerbose($"[ScopeHierarchy] Failed scanning player mesh roots: {ex.Message}");
+            }
+
+            if (scopeRoot != null)
+            {
+                Vector3 pivot = scopeRoot.position;
+                results.Sort((a, b) =>
+                {
+                    float da = (a.position - pivot).sqrMagnitude;
+                    float db = (b.position - pivot).sqrMagnitude;
+                    return da.CompareTo(db);
+                });
+            }
+
+            if (logCandidates)
+                PiPDisablerPlugin.LogInfo($"[MeshSurgery][DebugCandidates] player mesh roots found={results.Count}");
+
+            return results;
         }
 
         private static bool ContainsHandKeyword(string value)

--- a/Patches/MeshSurgeryManager.cs
+++ b/Patches/MeshSurgeryManager.cs
@@ -1060,6 +1060,36 @@ namespace PiPDisabler
             return null;
         }
 
+        public static Transform FindChildByPath(Transform root, string relativePath)
+        {
+            if (root == null || string.IsNullOrWhiteSpace(relativePath))
+                return null;
+
+            var parts = relativePath.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+            var current = root;
+            for (int i = 0; i < parts.Length; i++)
+            {
+                string seg = parts[i];
+                Transform next = null;
+                for (int c = 0; c < current.childCount; c++)
+                {
+                    var child = current.GetChild(c);
+                    if (child != null && string.Equals(child.name, seg, StringComparison.OrdinalIgnoreCase))
+                    {
+                        next = child;
+                        break;
+                    }
+                }
+
+                if (next == null)
+                    return null;
+
+                current = next;
+            }
+
+            return current;
+        }
+
         public static string GetRelativePath(Transform t, Transform root)
         {
             if (t == null) return "null";
@@ -1295,7 +1325,8 @@ namespace PiPDisabler
                 }
             }
 
-            var result = new List<MeshFilter>(64);
+            var result = new List<MeshFilter>(96);
+            var seen = new HashSet<int>();
             int skippedMode = 0, skippedOther = 0, skippedLightFx = 0;
             int inspected = 0;
 
@@ -1314,7 +1345,8 @@ namespace PiPDisabler
                 if (logCandidates)
                     relSearchPath = GetRelativePath(mf.transform, searchRoot);
 
-                result.Add(mf);
+                if (seen.Add(mf.GetInstanceID()))
+                    result.Add(mf);
 
                 if (logCandidates)
                 {
@@ -1322,6 +1354,8 @@ namespace PiPDisabler
                         $"[MeshSurgery][DebugCandidates] cuttable path='{relSearchPath}' go='{mf.gameObject.name}' mesh='{mf.sharedMesh.name}' verts={mf.sharedMesh.vertexCount} active={mf.gameObject.activeInHierarchy}");
                 }
             }
+
+            AddPlayerHandMeshes(scopeRoot, result, seen, logCandidates);
 
             PiPDisablerPlugin.LogVerbose(
                 $"[ScopeHierarchy] FindTargets from '{searchRoot.name}': " +
@@ -1334,6 +1368,55 @@ namespace PiPDisabler
             }
 
             return result;
+        }
+
+        private static void AddPlayerHandMeshes(Transform scopeRoot, List<MeshFilter> result,
+            HashSet<int> seen, bool logCandidates)
+        {
+            if (scopeRoot == null || result == null || seen == null)
+                return;
+
+            Transform playerMeshRoot = FindChildByPath(scopeRoot.root, "Player/Mesh");
+            if (playerMeshRoot == null)
+                return;
+
+            int added = 0;
+            foreach (var mf in playerMeshRoot.GetComponentsInChildren<MeshFilter>(true))
+            {
+                if (!mf || !mf.sharedMesh)
+                    continue;
+
+                string path = GetRelativePath(mf.transform, playerMeshRoot);
+                if (!ContainsHandKeyword(path) && !ContainsHandKeyword(mf.gameObject.name))
+                    continue;
+
+                if (!seen.Add(mf.GetInstanceID()))
+                    continue;
+
+                result.Add(mf);
+                added++;
+
+                if (logCandidates)
+                {
+                    PiPDisablerPlugin.LogInfo(
+                        $"[MeshSurgery][DebugCandidates] added-player-hand path='Player/Mesh/{path}' go='{mf.gameObject.name}' mesh='{mf.sharedMesh.name}' verts={mf.sharedMesh.vertexCount} active={mf.gameObject.activeInHierarchy}");
+                }
+            }
+
+            if (added > 0)
+            {
+                PiPDisablerPlugin.LogVerbose(
+                    $"[ScopeHierarchy] Added {added} player hand mesh(es) from '{playerMeshRoot.name}' to mesh surgery targets.");
+            }
+        }
+
+        private static bool ContainsHandKeyword(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+                return false;
+
+            string lower = value.ToLowerInvariant();
+            return lower.Contains("hand") || lower.Contains("hands");
         }
 
         /// <summary>


### PR DESCRIPTION
### Motivation
- Some player hand meshes under `Player/Mesh` were not being considered for plane cutting and therefore could remain visible through optics; the change aims to include those hand(s) meshes so they are processed by the mesh cutter.
- Overlapping search roots could produce duplicate `MeshFilter` entries causing redundant work or duplicate cuts, so deduplication is required.

### Description
- Extend `FindTargetMeshFilters` to deduplicate discovered `MeshFilter` entries by instance ID using a `HashSet<int>` and increase the initial collection capacity (`List<MeshFilter>(96)`).
- Add `FindChildByPath(Transform, string)` to locate a child by case-insensitive path segments and `ContainsHandKeyword(string)` to detect hand-related names.
- Add `AddPlayerHandMeshes` which scans `Player/Mesh` (from the scene root) and appends descendant `MeshFilter`s whose path or object name contains `hand`/`hands`, honoring deduplication and emitting debug/verbose logs when configured.
- Add informational logging for any player-hand meshes added to the target list to aid diagnostics when `GetDebugLogCutCandidates` is enabled.

### Testing
- Attempted to run `dotnet build` to validate compilation but the `dotnet` command is unavailable in this environment, so a compile check could not be performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5490759348328925fe57779f9e5ba)