### PR TITLE
Remove mesh cut caching system and related raid lifecycle logic

### DIFF
--- a/Patches/MeshSurgeryManager.cs
+++ b/Patches/MeshSurgeryManager.cs
@@ -1,9 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.IO;
-using System.Security.Cryptography;
-using System.Text;
 using EFT;
 using EFT.CameraControl;
 using EFT.InventoryLogic;
@@ -55,258 +52,6 @@ namespace PiPDisabler
         private static Delegate _removeItemHandler;
 
 
-        public static void ClearPersistentCache()
-        {
-            string cacheDir = PiPDisablerPlugin.GetMeshCutCacheDirectory();
-            if (!Directory.Exists(cacheDir)) return;
-
-            try
-            {
-                int removed = 0;
-                foreach (string cacheFile in Directory.GetFiles(cacheDir, "*.bin"))
-                {
-                    File.Delete(cacheFile);
-                    removed++;
-                }
-
-                PiPDisablerPlugin.LogInfo(
-                    $"[MeshSurgery] Cleared persistent mesh cache: removed {removed} file(s).");
-            }
-            catch (Exception ex)
-            {
-                PiPDisablerPlugin.LogWarn(
-                    $"[MeshSurgery] Failed to clear persistent cache: {ex.Message}");
-            }
-        }
-
-        private static class MeshCutCache
-        {
-            private const int Version = 1;
-
-            public static bool TryLoad(string key, out Mesh mesh)
-            {
-                mesh = null;
-                string path = GetPath(key);
-                if (!File.Exists(path)) return false;
-
-                try
-                {
-                    using (var fs = File.OpenRead(path))
-                    using (var br = new BinaryReader(fs))
-                    {
-                        if (br.ReadInt32() != Version) return false;
-
-                        int vertexCount = br.ReadInt32();
-                        if (vertexCount < 0) return false;
-
-                        var vertices = new Vector3[vertexCount];
-                        for (int i = 0; i < vertexCount; i++)
-                            vertices[i] = new Vector3(br.ReadSingle(), br.ReadSingle(), br.ReadSingle());
-
-                        var normals = new Vector3[vertexCount];
-                        for (int i = 0; i < vertexCount; i++)
-                            normals[i] = new Vector3(br.ReadSingle(), br.ReadSingle(), br.ReadSingle());
-
-                        var tangents = new Vector4[vertexCount];
-                        for (int i = 0; i < vertexCount; i++)
-                            tangents[i] = new Vector4(br.ReadSingle(), br.ReadSingle(), br.ReadSingle(), br.ReadSingle());
-
-                        var uv = new Vector2[vertexCount];
-                        for (int i = 0; i < vertexCount; i++)
-                            uv[i] = new Vector2(br.ReadSingle(), br.ReadSingle());
-
-                        var indexFormat = (UnityEngine.Rendering.IndexFormat)br.ReadInt32();
-                        int subMeshCount = br.ReadInt32();
-                        if (subMeshCount <= 0) return false;
-
-                        var cachedMesh = new Mesh();
-                        cachedMesh.name = "mesh_cut_cached";
-                        cachedMesh.indexFormat = indexFormat;
-                        cachedMesh.vertices = vertices;
-                        cachedMesh.normals = normals;
-                        cachedMesh.tangents = tangents;
-                        cachedMesh.uv = uv;
-                        cachedMesh.subMeshCount = subMeshCount;
-
-                        for (int s = 0; s < subMeshCount; s++)
-                        {
-                            int triCount = br.ReadInt32();
-                            if (triCount < 0) return false;
-
-                            var tris = new int[triCount];
-                            for (int t = 0; t < triCount; t++)
-                                tris[t] = br.ReadInt32();
-                            cachedMesh.SetTriangles(tris, s, true);
-                        }
-
-                        cachedMesh.RecalculateBounds();
-                        mesh = cachedMesh;
-                        return true;
-                    }
-                }
-                catch (Exception ex)
-                {
-                    PiPDisablerPlugin.LogVerbose($"[MeshSurgery] Cache load failed '{path}': {ex.Message}");
-                    return false;
-                }
-            }
-
-            public static void Save(string key, Mesh mesh)
-            {
-                if (mesh == null) return;
-
-                string path = GetPath(key);
-                string tmpPath = path + ".tmp";
-
-                try
-                {
-                    var vertices = mesh.vertices ?? Array.Empty<Vector3>();
-                    var normals = mesh.normals;
-                    var tangents = mesh.tangents;
-                    var uv = mesh.uv;
-
-                    if (normals == null || normals.Length != vertices.Length)
-                    {
-                        mesh.RecalculateNormals();
-                        normals = mesh.normals;
-                    }
-                    if (tangents == null || tangents.Length != vertices.Length)
-                        tangents = new Vector4[vertices.Length];
-                    if (uv == null || uv.Length != vertices.Length)
-                        uv = new Vector2[vertices.Length];
-
-                    using (var fs = File.Create(tmpPath))
-                    using (var bw = new BinaryWriter(fs))
-                    {
-                        bw.Write(Version);
-                        bw.Write(vertices.Length);
-
-                        for (int i = 0; i < vertices.Length; i++)
-                        {
-                            bw.Write(vertices[i].x); bw.Write(vertices[i].y); bw.Write(vertices[i].z);
-                        }
-                        for (int i = 0; i < normals.Length; i++)
-                        {
-                            bw.Write(normals[i].x); bw.Write(normals[i].y); bw.Write(normals[i].z);
-                        }
-                        for (int i = 0; i < tangents.Length; i++)
-                        {
-                            bw.Write(tangents[i].x); bw.Write(tangents[i].y); bw.Write(tangents[i].z); bw.Write(tangents[i].w);
-                        }
-                        for (int i = 0; i < uv.Length; i++)
-                        {
-                            bw.Write(uv[i].x); bw.Write(uv[i].y);
-                        }
-
-                        bw.Write((int)mesh.indexFormat);
-                        bw.Write(mesh.subMeshCount);
-                        for (int s = 0; s < mesh.subMeshCount; s++)
-                        {
-                            var tris = mesh.GetTriangles(s);
-                            bw.Write(tris.Length);
-                            for (int t = 0; t < tris.Length; t++) bw.Write(tris[t]);
-                        }
-                    }
-
-                    if (File.Exists(path)) File.Delete(path);
-                    File.Move(tmpPath, path);
-                }
-                catch (Exception ex)
-                {
-                    PiPDisablerPlugin.LogVerbose($"[MeshSurgery] Cache save failed '{path}': {ex.Message}");
-                    try { if (File.Exists(tmpPath)) File.Delete(tmpPath); } catch { }
-                }
-            }
-
-            public static string BuildKey(Transform scopeRoot, Transform activeMode, MeshFilter mf, Mesh originalAsset, MeshPlaneCutter.KeepSide keepSide, bool isCylinder)
-            {
-                var sb = new StringBuilder(512);
-                sb.Append("v3|");
-                sb.Append(scopeRoot != null ? scopeRoot.name : "scope").Append('|');
-                sb.Append(activeMode != null ? activeMode.name : "mode").Append('|');
-                sb.Append(GetRelativePath(scopeRoot, mf != null ? mf.transform : null)).Append('|');
-                sb.Append(originalAsset != null ? originalAsset.name : "null").Append('|');
-                sb.Append(originalAsset != null ? originalAsset.vertexCount : 0).Append('|');
-                sb.Append(originalAsset != null ? originalAsset.subMeshCount : 0).Append('|');
-                sb.Append((int)keepSide).Append('|');
-                sb.Append(isCylinder ? "cyl" : "plane").Append('|');
-
-                if (isCylinder)
-                {
-                    AppendFloat(sb, PiPDisablerPlugin.GetCylinderRadius());
-                    AppendFloat(sb, PiPDisablerPlugin.GetCutStartOffset());
-                    AppendFloat(sb, PiPDisablerPlugin.GetCutLength());
-                    AppendFloat(sb, PiPDisablerPlugin.GetNearPreserveDepth());
-                    AppendFloat(sb, PiPDisablerPlugin.GetPlane2PositionNormalized(PiPDisablerPlugin.GetCutLength()));
-                    AppendFloat(sb, PiPDisablerPlugin.GetPlane2Radius());
-                    AppendFloat(sb, PiPDisablerPlugin.GetPlane3Position());
-                    AppendFloat(sb, PiPDisablerPlugin.GetPlane3Radius());
-                    AppendFloat(sb, PiPDisablerPlugin.GetPlane4Position());
-                    AppendFloat(sb, PiPDisablerPlugin.GetPlane4Radius());
-                    AppendFloat(sb, PiPDisablerPlugin.GetPlane1OffsetMeters());
-                }
-                else
-                {
-                    AppendFloat(sb, PiPDisablerPlugin.GetPlaneOffsetMeters());
-                }
-
-                using (var sha = SHA256.Create())
-                {
-                    var bytes = Encoding.UTF8.GetBytes(sb.ToString());
-                    var hash = sha.ComputeHash(bytes);
-                    var hex = new StringBuilder(hash.Length * 2);
-                    for (int i = 0; i < hash.Length; i++)
-                        hex.Append(hash[i].ToString("x2"));
-                    string scopeName = Sanitize(scopeRoot != null ? scopeRoot.name : "scope");
-                    string meshName = Sanitize(originalAsset != null ? originalAsset.name : "mesh");
-                    return scopeName + "__" + meshName + "__" + hex;
-                }
-            }
-
-            private static string GetPath(string key)
-            {
-                return Path.Combine(PiPDisablerPlugin.GetMeshCutCacheDirectory(), key + ".bin");
-            }
-
-            private static string GetRelativePath(Transform root, Transform child)
-            {
-                if (child == null) return "none";
-                if (root == null) return child.name ?? "unnamed";
-
-                var nodes = new List<string>();
-                for (var t = child; t != null; t = t.parent)
-                {
-                    nodes.Add(t.name ?? "unnamed");
-                    if (t == root) break;
-                }
-                nodes.Reverse();
-                return string.Join("/", nodes.ToArray());
-            }
-
-            private static string Sanitize(string value)
-            {
-                if (string.IsNullOrEmpty(value)) return "unknown";
-                var invalid = Path.GetInvalidFileNameChars();
-                var sb = new StringBuilder(value.Length);
-                for (int i = 0; i < value.Length; i++)
-                {
-                    char c = value[i];
-                    bool bad = false;
-                    for (int j = 0; j < invalid.Length; j++)
-                    {
-                        if (c == invalid[j]) { bad = true; break; }
-                    }
-                    if (bad || char.IsWhiteSpace(c)) sb.Append('_');
-                    else sb.Append(c);
-                }
-                return sb.ToString();
-            }
-
-            private static void AppendFloat(StringBuilder sb, float v)
-            {
-                sb.Append(Mathf.Round(v * 1000f) / 1000f).Append('|');
-            }
-        }
 
         public static void ApplyForOptic(OpticSight os)
         {
@@ -488,70 +233,57 @@ namespace PiPDisabler
 
                 try
                 {
-                    bool isCylinder = PiPDisablerPlugin.GetCutMode() == "Cylinder";
-                    string cacheKey = MeshCutCache.BuildKey(scopeRoot, activeMode, mf, originalAsset, keepSide, isCylinder);
+                    Mesh readable = MeshPlaneCutter.MakeReadableMeshCopy(originalAsset);
+                    if (readable == null)
+                        continue;
 
-                    Mesh readable;
-                    if (MeshCutCache.TryLoad(cacheKey, out var cachedMesh))
+                    if (!_loggedGpuCopy)
                     {
-                        readable = cachedMesh;
-                        readable.name = originalAsset.name + "_CUT_CACHED";
+                        _loggedGpuCopy = true;
+                        PiPDisablerPlugin.LogInfo(
+                            "[MeshSurgery] Created readable mesh copies via GPU buffer. Plane cutting enabled.");
+                    }
+
+                    int vertsBefore = readable.vertexCount;
+                    bool ok;
+                    bool isCylinder = PiPDisablerPlugin.GetCutMode() == "Cylinder";
+                    if (isCylinder)
+                    {
+                        float nearR = PiPDisablerPlugin.GetCylinderRadius();
+                        float startOff = PiPDisablerPlugin.GetCutStartOffset();
+                        float cutLen = PiPDisablerPlugin.GetCutLength();
+                        float preserve = PiPDisablerPlugin.GetNearPreserveDepth();
+                        float p2 = PiPDisablerPlugin.GetPlane2PositionNormalized(cutLen);
+                        float r2 = PiPDisablerPlugin.GetPlane2Radius();
+                        float p3 = PiPDisablerPlugin.GetPlane3Position();
+                        float r3 = PiPDisablerPlugin.GetPlane3Radius();
+                        float p4 = PiPDisablerPlugin.GetPlane4Position();
+                        float r4 = PiPDisablerPlugin.GetPlane4Radius();
+
+                        ok = MeshPlaneCutter.CutMeshFrustum(readable, mf.transform,
+                            planePoint, planeNormal, nearR, r4, startOff, cutLen,
+                            keepInside: false, midRadius: r2, midPosition: p2,
+                            nearPreserveDepth: preserve,
+                            plane3Radius: r3, plane3Position: p3, plane4Position: p4);
                     }
                     else
                     {
-                        readable = MeshPlaneCutter.MakeReadableMeshCopy(originalAsset);
-                        if (readable == null)
-                            continue;
-
-                        if (!_loggedGpuCopy)
-                        {
-                            _loggedGpuCopy = true;
-                            PiPDisablerPlugin.LogInfo(
-                                "[MeshSurgery] Created readable mesh copies via GPU buffer. Plane cutting enabled.");
-                        }
-
-                        int vertsBefore = readable.vertexCount;
-                        bool ok;
-                        if (isCylinder)
-                        {
-                            float nearR = PiPDisablerPlugin.GetCylinderRadius();
-                            float startOff = PiPDisablerPlugin.GetCutStartOffset();
-                            float cutLen = PiPDisablerPlugin.GetCutLength();
-                            float preserve = PiPDisablerPlugin.GetNearPreserveDepth();
-                            float p2 = PiPDisablerPlugin.GetPlane2PositionNormalized(cutLen);
-                            float r2 = PiPDisablerPlugin.GetPlane2Radius();
-                            float p3 = PiPDisablerPlugin.GetPlane3Position();
-                            float r3 = PiPDisablerPlugin.GetPlane3Radius();
-                            float p4 = PiPDisablerPlugin.GetPlane4Position();
-                            float r4 = PiPDisablerPlugin.GetPlane4Radius();
-
-                            ok = MeshPlaneCutter.CutMeshFrustum(readable, mf.transform,
-                                planePoint, planeNormal, nearR, r4, startOff, cutLen,
-                                keepInside: false, midRadius: r2, midPosition: p2,
-                                nearPreserveDepth: preserve,
-                                plane3Radius: r3, plane3Position: p3, plane4Position: p4);
-                        }
-                        else
-                        {
-                            ok = MeshPlaneCutter.CutMeshDirect(readable, mf.transform,
-                                planePoint, planeNormal, keepSide);
-                        }
-
-                        if (!ok)
-                        {
-                            readable.Clear();
-                            readable.name = originalAsset.name + "_CUT_EMPTY";
-                        }
-                        else
-                        {
-                            readable.name = originalAsset.name + "_CUT";
-                        }
-
-                        PiPDisablerPlugin.LogVerbose(
-                            $"[MeshSurgery] Cut '{originalAsset.name}': {vertsBefore} → {readable.vertexCount} verts");
-
-                        MeshCutCache.Save(cacheKey, readable);
+                        ok = MeshPlaneCutter.CutMeshDirect(readable, mf.transform,
+                            planePoint, planeNormal, keepSide);
                     }
+
+                    if (!ok)
+                    {
+                        readable.Clear();
+                        readable.name = originalAsset.name + "_CUT_EMPTY";
+                    }
+                    else
+                    {
+                        readable.name = originalAsset.name + "_CUT";
+                    }
+
+                    PiPDisablerPlugin.LogVerbose(
+                        $"[MeshSurgery] Cut '{originalAsset.name}': {vertsBefore} → {readable.vertexCount} verts");
 
                     mf.sharedMesh = readable;
                     cache.Entries.Add(new CutMeshEntry

--- a/PiPDisablerPlugin.cs
+++ b/PiPDisablerPlugin.cs
@@ -90,7 +90,6 @@ namespace PiPDisabler
         internal static ConfigEntry<bool> EnableMeshSurgery;
         internal static ConfigEntry<KeyCode> MeshSurgeryToggleKey;
         internal static ConfigEntry<bool> RestoreOnUnscope;
-        internal static ConfigEntry<bool> ClearMeshCacheOnRaidEnd;
         internal static ConfigEntry<float> PlaneOffsetMeters;
         internal static ConfigEntry<string> PlaneNormalAxis;
         internal static ConfigEntry<float> CutRadius;
@@ -188,7 +187,6 @@ namespace PiPDisabler
         internal static ConfigEntry<bool> DebugLogCutCandidates;
         internal static ConfigEntry<bool> DebugReticleAfterEverything;
 
-        private bool _wasInRaid;
 
         private void Awake()
         {
@@ -320,8 +318,6 @@ namespace PiPDisabler
                 "Toggle key for mesh surgery.");
             RestoreOnUnscope = Config.Bind("3. Global Mesh Surgery settings", "RestoreOnUnscope", true,
                 "Restore original meshes when leaving scope.");
-            ClearMeshCacheOnRaidEnd = Config.Bind("3. Global Mesh Surgery settings", "ClearMeshCacheOnRaidEnd", true,
-                "Clear persisted mesh-cut cache files when transitioning from raid to out-of-raid.");
             PlaneOffsetMeters = Config.Bind("3. Global Mesh Surgery settings", "PlaneOffsetMeters", 0.001f,
                 "Offset applied along plane normal (meters).");
             PlaneNormalAxis = Config.Bind("3. Global Mesh Surgery settings", "PlaneNormalAxis", "-Y",
@@ -556,7 +552,7 @@ namespace PiPDisabler
             LogInfo($"  WhitelistNames='{ScopeWhitelistNames.Value}'");
             LogInfo($"  EnableZoom={EnableZoom.Value}");
             LogInfo($"  AutoFov={AutoFovFromScope.Value}  DefaultZoom={DefaultZoom.Value}  FovAnimDur={FovAnimationDuration.Value}s");
-            LogInfo($"  EnableMeshSurgery={EnableMeshSurgery.Value}  CutMode={CutMode.Value}  CutLen={CutLength.Value}  NearPreserve={NearPreserveDepth.Value}  ShowReticle={ShowReticle.Value}  ClearMeshCacheOnRaidEnd={ClearMeshCacheOnRaidEnd.Value}");
+            LogInfo($"  EnableMeshSurgery={EnableMeshSurgery.Value}  CutMode={CutMode.Value}  CutLen={CutLength.Value}  NearPreserve={NearPreserveDepth.Value}  ShowReticle={ShowReticle.Value}");
         }
 
         private static ScopeMeshSurgerySettingsEntry ActiveScopeOverride => PerScopeMeshSurgerySettings.GetActiveOverride();
@@ -660,13 +656,6 @@ namespace PiPDisabler
 
         private void Update()
         {
-            bool inRaid = IsInRaid();
-            if (ClearMeshCacheOnRaidEnd.Value && _wasInRaid && !inRaid)
-            {
-                MeshSurgeryManager.ClearPersistentCache();
-            }
-            _wasInRaid = inRaid;
-
             // --- Global mod toggle (always active, even when mod is OFF) ---
             if (ModToggleKey.Value != KeyCode.None && InputProxy.GetKeyDown(ModToggleKey.Value))
             {
@@ -760,18 +749,6 @@ namespace PiPDisabler
 
             // Per-frame maintenance (ensure lens hidden, update variable zoom, etc.)
             ScopeLifecycle.Tick();
-        }
-        private static bool IsInRaid()
-        {
-            try
-            {
-                var gw = Singleton<GameWorld>.Instance;
-                return gw != null && gw.MainPlayer != null;
-            }
-            catch
-            {
-                return false;
-            }
         }
 
         internal static string GetCurrentLocationId()


### PR DESCRIPTION
## Summary
This PR removes the persistent mesh cut caching system that was previously used to store and reuse computed mesh cuts across sessions. The caching infrastructure, including file I/O operations and SHA256-based cache key generation, has been completely removed in favor of computing mesh cuts on-demand each time they're needed.

## Key Changes
- **Removed `MeshCutCache` class**: Eliminated the entire nested class that handled binary serialization/deserialization of cut meshes, including:
  - `TryLoad()` and `Save()` methods for cache persistence
  - `BuildKey()` method for generating cache keys using SHA256 hashing
  - Helper methods for path management and string sanitization
  
- **Removed `ClearPersistentCache()` method**: Deleted the public method that cleared cached mesh files from disk

- **Simplified mesh cutting logic**: Modified `RebuildCutCacheForOptic()` to always compute mesh cuts directly instead of checking the cache first, removing the conditional cache lookup path

- **Removed raid lifecycle tracking**: 
  - Deleted `_wasInRaid` field from `PiPDisablerPlugin`
  - Removed `IsInRaid()` method
  - Removed cache clearing logic from `Update()` that triggered on raid transitions
  
- **Removed configuration option**: Deleted `ClearMeshCacheOnRaidEnd` config entry and its associated binding

- **Removed unused imports**: Cleaned up `using System.IO`, `using System.Security.Cryptography`, and `using System.Text` from `MeshSurgeryManager.cs`

## Implementation Details
The mesh cutting now happens on-demand without caching, which simplifies the codebase at the cost of recomputing cuts when needed. The core mesh cutting algorithms (`CutMeshFrustum` and `CutMeshDirect`) remain unchanged and continue to be called directly.

https://claude.ai/code/session_019JKcjb1sQyNJepadc7EZMY