### PR TITLE
Add optional runtime Fika main-camera projection compatibility patches

### DIFF
--- a/Patches/FikaMainCameraMarkerCompatPatch.cs
+++ b/Patches/FikaMainCameraMarkerCompatPatch.cs
@@ -1,0 +1,91 @@
+using System.Collections.Generic;
+using System.Reflection;
+using System.Reflection.Emit;
+using BepInEx.Configuration;
+using HarmonyLib;
+using SPT.Reflection.Patching;
+
+namespace PiPDisabler.Patches
+{
+    internal sealed class FikaPingMainCameraCompatPatch : ModulePatch
+    {
+        protected override MethodBase GetTargetMethod()
+        {
+            var type = AccessTools.TypeByName("Fika.Core.Main.Factories.PingFactory+AbstractPing");
+            return type != null ? AccessTools.Method(type, "Update") : null;
+        }
+
+        [PatchTranspiler]
+        private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+        {
+            var fikaConfigType = AccessTools.TypeByName("Fika.Core.FikaConfig");
+            var pingUseOpticZoomGetter = fikaConfigType != null
+                ? AccessTools.PropertyGetter(fikaConfigType, "PingUseOpticZoom")
+                : null;
+            var configValueGetter = AccessTools.PropertyGetter(typeof(ConfigEntry<bool>), "Value");
+
+            bool replaced = false;
+            var list = new List<CodeInstruction>(instructions);
+            for (int i = 0; i < list.Count; i++)
+            {
+                if (!replaced && pingUseOpticZoomGetter != null && configValueGetter != null &&
+                    i + 1 < list.Count &&
+                    list[i].Calls(pingUseOpticZoomGetter) &&
+                    list[i + 1].Calls(configValueGetter))
+                {
+                    yield return new CodeInstruction(OpCodes.Pop);
+                    yield return new CodeInstruction(OpCodes.Ldc_I4_0);
+                    i++;
+                    replaced = true;
+                    continue;
+                }
+
+                yield return list[i];
+            }
+
+            if (!replaced)
+                PiPDisablerPlugin.LogWarn("[FikaCompat] Ping patch did not find PingUseOpticZoom IL pattern.");
+        }
+    }
+
+    internal sealed class FikaHealthBarMainCameraCompatPatch : ModulePatch
+    {
+        protected override MethodBase GetTargetMethod()
+        {
+            var type = AccessTools.TypeByName("Fika.Core.Main.Components.FikaHealthBar");
+            return type != null ? AccessTools.Method(type, "UpdateScreenSpacePosition") : null;
+        }
+
+        [PatchTranspiler]
+        private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+        {
+            var fikaConfigType = AccessTools.TypeByName("Fika.Core.FikaConfig");
+            var namePlateUseOpticZoomGetter = fikaConfigType != null
+                ? AccessTools.PropertyGetter(fikaConfigType, "NamePlateUseOpticZoom")
+                : null;
+            var configValueGetter = AccessTools.PropertyGetter(typeof(ConfigEntry<bool>), "Value");
+
+            bool replaced = false;
+            var list = new List<CodeInstruction>(instructions);
+            for (int i = 0; i < list.Count; i++)
+            {
+                if (!replaced && namePlateUseOpticZoomGetter != null && configValueGetter != null &&
+                    i + 1 < list.Count &&
+                    list[i].Calls(namePlateUseOpticZoomGetter) &&
+                    list[i + 1].Calls(configValueGetter))
+                {
+                    yield return new CodeInstruction(OpCodes.Pop);
+                    yield return new CodeInstruction(OpCodes.Ldc_I4_0);
+                    i++;
+                    replaced = true;
+                    continue;
+                }
+
+                yield return list[i];
+            }
+
+            if (!replaced)
+                PiPDisablerPlugin.LogWarn("[FikaCompat] Health bar patch did not find NamePlateUseOpticZoom IL pattern.");
+        }
+    }
+}

--- a/Patches/Patcher.cs
+++ b/Patches/Patcher.cs
@@ -27,6 +27,10 @@ namespace PiPDisabler.Patches
 
             // Weapon scaling (freeze ribcage scale while scoped)
             SafeEnable<WeaponScalingPatch>();
+
+            // Fika optional compatibility (force marker projection to main camera)
+            SafeEnable<FikaPingMainCameraCompatPatch>();
+            SafeEnable<FikaHealthBarMainCameraCompatPatch>();
         }
 
         private static void SafeEnable<T>() where T : ModulePatch, new()

--- a/PiPDisablerPlugin.cs
+++ b/PiPDisablerPlugin.cs
@@ -11,6 +11,7 @@ using UnityEngine;
 namespace PiPDisabler
 {
     [BepInPlugin("com.fiodor.pipdisabler", "PiP-Disabler", "0.1.0")]
+    [BepInDependency("com.fika.core", BepInDependency.DependencyFlags.SoftDependency)]
     public sealed class PiPDisablerPlugin : BaseUnityPlugin
     {
         internal static PiPDisablerPlugin Instance;


### PR DESCRIPTION
### Motivation
- Ensure Fika coop pings, name plates, and health bars always use the main camera projection when Fika is present to prevent UI drift under PiP Disabler's main-camera ADS FOV changes.
- Implement the compatibility entirely at runtime from PiP Disabler without adding a compile-time reference to Fika and make it optional when Fika is not installed.

### Description
- Add a soft dependency on Fika by adding `[BepInDependency("com.fika.core", BepInDependency.DependencyFlags.SoftDependency)]` to `PiPDisablerPlugin.cs` so compatibility stays optional and the plugin GUID/name/version are unchanged.
- Add `Patches/FikaMainCameraMarkerCompatPatch.cs` containing two `ModulePatch` transpiler patches that resolve Fika types via `AccessTools.TypeByName` and do not hard-reference Fika assemblies at compile time.
- In each transpiler the IL sequence that calls the Fika config getter (`PingUseOpticZoom` / `NamePlateUseOpticZoom`) followed by `ConfigEntry<bool>.Value` is replaced with the IL equivalent of `pop` + `ldc.i4.0` so the final calls behave as if `false` was passed (i.e. `WorldToScreen.ProjectToCanvas(..., false, ...)`).
- Register both patches in `Patches/Patcher.cs` using `SafeEnable<FikaPingMainCameraCompatPatch>()` and `SafeEnable<FikaHealthBarMainCameraCompatPatch>()` so they are attempted at runtime but do not crash the mod if Fika is absent.
- The change does not patch `WorldToScreen.ProjectToCanvas` globally and does not modify any Fika source files or config entries.

### Testing
- Attempted to run `dotnet build -c Release` in the environment, but it failed because `dotnet` is not available in this environment (`bash: command not found: dotnet`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b59430726c83288556ac9ab956a233)