### PR TITLE
Pre-warm mesh surgery and shader resources on startup

### DIFF
--- a/Patches/LensTransparency.cs
+++ b/Patches/LensTransparency.cs
@@ -62,6 +62,20 @@ namespace PiPDisabler
         // Solid black unlit material applied to lens surfaces when unscoped.
         private static Material _blackLensMaterial;
 
+        /// <summary>
+        /// Pre-warm the empty mesh and black lens material at startup so they are not
+        /// created on the first ADS frame.  Safe to call multiple times.
+        /// </summary>
+        public static void PreWarm()
+        {
+            try
+            {
+                GetEmptyMesh();
+                GetBlackLensMaterial();
+            }
+            catch { }
+        }
+
         private static Mesh GetEmptyMesh()
         {
             if (_emptyMesh != null) return _emptyMesh;

--- a/Patches/MeshSurgeryManager.cs
+++ b/Patches/MeshSurgeryManager.cs
@@ -80,9 +80,42 @@ namespace PiPDisabler
             }
 
             if (cache.Dirty || !cache.Built)
-                RebuildCutCacheForOptic(cache, os, scopeRoot, activeMode);
+                RebuildCutCacheForOptic(cache, os, scopeRoot, activeMode, applyMeshes: true);
             else
                 ReapplyCachedCutMeshes(cache, scopeRoot);
+        }
+
+        /// <summary>
+        /// Pre-warm the mesh surgery cut cache for <paramref name="os"/> WITHOUT applying
+        /// the cut meshes to any MeshFilters.  Call this when the weapon is equipped but
+        /// the player is not yet ADS'd so the expensive GPU readback + CPU cutting work
+        /// happens outside the ADS transition.  When the player later ADS with the same
+        /// weapon, <see cref="ApplyForOptic"/> finds the cache already built and takes the
+        /// fast <see cref="ReapplyCachedCutMeshes"/> path (no GPU stall, no mesh cutting).
+        /// </summary>
+        public static void TryPreWarmForOptic(OpticSight os)
+        {
+            if (os == null) return;
+
+            var scopeRoot = ScopeHierarchy.FindScopeRoot(os.transform);
+            if (!scopeRoot) return;
+
+            var activeMode = ResolveActiveMode(os, scopeRoot);
+            var cache = GetOrCreateCurrentWeaponCache(scopeRoot, activeMode);
+            if (cache == null) return;
+
+            // Already warm — nothing to do.
+            if (cache.Built && !cache.Dirty) return;
+
+            string currentSignature = BuildCutSettingsSignature();
+            if (cache.Built && !string.Equals(cache.SettingsSignature, currentSignature, StringComparison.Ordinal))
+                cache.Dirty = true;
+
+            if (cache.Dirty || !cache.Built)
+            {
+                PiPDisablerPlugin.LogInfo("[MeshSurgery] Pre-warming cut cache (no-apply pass).");
+                RebuildCutCacheForOptic(cache, os, scopeRoot, activeMode, applyMeshes: false);
+            }
         }
 
         public static void RestoreForScope(Transform anyTransformUnderScope)
@@ -201,7 +234,7 @@ namespace PiPDisabler
             return profileCache;
         }
 
-        private static void RebuildCutCacheForOptic(CutProfileCache cache, OpticSight os, Transform scopeRoot, Transform activeMode)
+        private static void RebuildCutCacheForOptic(CutProfileCache cache, OpticSight os, Transform scopeRoot, Transform activeMode, bool applyMeshes = true)
         {
             if (cache == null || os == null || scopeRoot == null) return;
             if (!activeMode) activeMode = os.transform;
@@ -226,7 +259,8 @@ namespace PiPDisabler
                 ? MeshPlaneCutter.KeepSide.Positive
                 : MeshPlaneCutter.KeepSide.Negative;
 
-            PlaneVisualizer.Show(planePoint, planeNormal);
+            if (applyMeshes)
+                PlaneVisualizer.Show(planePoint, planeNormal);
 
             RestoreOriginalMeshes(cache);
             DestroyCutMeshes(cache);
@@ -236,8 +270,12 @@ namespace PiPDisabler
             float cutRadius = PiPDisablerPlugin.GetCutRadius();
             bool logCandidates = PiPDisablerPlugin.GetDebugLogCutCandidates();
 
-            DisableLightEffectMeshesForScope(scopeRoot, logCandidates);
-            DisableWeaponSphereObjects(scopeRoot, logCandidates);
+            // Light/sphere effects are visual-state changes — only apply during a real ADS enter.
+            if (applyMeshes)
+            {
+                DisableLightEffectMeshesForScope(scopeRoot, logCandidates);
+                DisableWeaponSphereObjects(scopeRoot, logCandidates);
+            }
 
             foreach (var mf in targets)
             {
@@ -306,13 +344,18 @@ namespace PiPDisabler
                     PiPDisablerPlugin.LogVerbose(
                         $"[MeshSurgery] Cut '{originalAsset.name}': {vertsBefore} → {readable.vertexCount} verts");
 
-                    mf.sharedMesh = readable;
+                    // When pre-warming (applyMeshes=false) we build the cut mesh but do NOT
+                    // assign it to the MeshFilter yet — that happens later in ApplyForOptic /
+                    // ReapplyCachedCutMeshes when the player actually ADS.
+                    if (applyMeshes)
+                        mf.sharedMesh = readable;
+
                     cache.Entries.Add(new CutMeshEntry
                     {
                         Filter = mf,
                         OriginalMesh = originalAsset,
                         CutMesh = readable,
-                        Applied = true,
+                        Applied = applyMeshes,
                         FilterPath = GetRelativePath(weaponRootTf, mf.transform)
                     });
                 }

--- a/Patches/ReticleRenderer.cs
+++ b/Patches/ReticleRenderer.cs
@@ -535,6 +535,17 @@ namespace PiPDisabler
             };
         }
 
+        /// <summary>
+        /// Pre-warm the reticle mesh and all shader materials at startup so that
+        /// Shader.Find and new Material() do not run on the first ADS frame.
+        /// Safe to call multiple times — creation is skipped if already done.
+        /// </summary>
+        public static void PreWarmMaterials()
+        {
+            try { EnsureMeshAndMaterial(); }
+            catch { }
+        }
+
         private static void EnsureMeshAndMaterial()
         {
             if (_reticleMesh != null && _reticleMat != null) return;

--- a/Patches/ScopeLifecycle.cs
+++ b/Patches/ScopeLifecycle.cs
@@ -246,6 +246,14 @@ namespace PiPDisabler
             }
 
             CheckAndUpdate("OnOpticEnabled");
+
+            // If we did NOT enter scope (player isn't ADS'd yet), pre-warm the mesh surgery
+            // cut cache now.  The expensive GPU readbacks and CPU mesh cutting happen here,
+            // during weapon equip / collimator-mode activation, rather than on the first ADS
+            // frame.  When the player ADS, ApplyForOptic finds the cache already built and
+            // takes the fast ReapplyCachedCutMeshes path.
+            if (!_isScoped && os != null && PiPDisablerPlugin.EnableMeshSurgery.Value)
+                MeshSurgeryManager.TryPreWarmForOptic(os);
         }
 
         /// <summary>

--- a/PiPDisablerPlugin.cs
+++ b/PiPDisablerPlugin.cs
@@ -576,6 +576,11 @@ namespace PiPDisabler
             // Initialize scope detection via PWA reflection
             ScopeLifecycle.Init();
 
+            // Pre-warm shader/material resources so they are not created on the first ADS frame.
+            // These calls are idempotent — safe to invoke during Awake before any scene is loaded.
+            ReticleRenderer.PreWarmMaterials();
+            LensTransparency.PreWarm();
+
             // --- Config change handlers (catches config manager changes, not just hotkeys) ---
             ModEnabled.SettingChanged += OnModEnabledChanged;
             EnableWeaponScaling.SettingChanged += OnWeaponScalingToggled;


### PR DESCRIPTION
## Summary
This PR optimizes the ADS (aim-down-sights) experience by pre-warming expensive mesh surgery and shader resources during plugin initialization, rather than on the first ADS frame. This eliminates GPU stalls and mesh cutting operations from the ADS transition, improving frame timing when the player first scopes in.

## Key Changes

- **MeshSurgeryManager**: Added `TryPreWarmForOptic()` method to build the mesh cut cache without applying meshes to MeshFilters. Modified `RebuildCutCacheForOptic()` to accept an `applyMeshes` parameter that controls whether cut meshes are assigned and visual effects (plane visualizer, light/sphere disabling) are applied.

- **LensTransparency**: Added `PreWarm()` method to initialize the empty mesh and black lens material at startup.

- **ReticleRenderer**: Added `PreWarmMaterials()` method to ensure the reticle mesh and shader materials are created during initialization.

- **ScopeLifecycle**: Modified `OnOpticEnabled()` to call `MeshSurgeryManager.TryPreWarmForOptic()` when a scope is equipped but not yet active (player not ADS'd), deferring the expensive mesh surgery work to weapon equip time.

- **PiPDisablerPlugin**: Added pre-warming calls in `Awake()` to initialize reticle and lens transparency resources before any scene loads.

## Implementation Details

- The pre-warming is idempotent — all new methods safely handle being called multiple times.
- When `applyMeshes=false`, cut meshes are built and cached but not assigned to MeshFilters; they are applied later by `ReapplyCachedCutMeshes()` during actual ADS.
- Visual state changes (plane visualizer, light/sphere effect disabling) only occur during real ADS entry (`applyMeshes=true`), not during pre-warming.
- The `CutMeshEntry.Applied` flag correctly reflects whether meshes have been assigned to filters.

https://claude.ai/code/session_01H5EQek9v437wQiYnqCGYe7