### PR TITLE
Mark most config entries as advanced and add Bind helper

### DIFF
--- a/PiPDisablerPlugin.cs
+++ b/PiPDisablerPlugin.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using BepInEx;
 using BepInEx.Configuration;
 using Comfort.Common;
@@ -228,101 +229,144 @@ namespace PiPDisabler
         internal static ConfigEntry<bool> DebugLogCutCandidates;
         internal static ConfigEntry<bool> DebugReticleAfterEverything;
 
+        private static readonly HashSet<string> BasicSettings = new HashSet<string>(StringComparer.Ordinal)
+        {
+            "0. Global|ModEnabled",
+            "1. General|ScopeWhitelistNames",
+            "1. General|ScopeWhitelistToggleEntryKey",
+            "2. Zoom|FovAnimationDuration",
+            "5. Scope Effects|VignetteEnabled",
+            "6. Diagnostics|DiagnosticsKey",
+            "7. Debug|VerboseLogging"
+        };
+
+        private sealed class ConfigurationManagerAttributes
+        {
+            public bool IsAdvanced { get; set; }
+        }
+
+        private ConfigEntry<T> Bind<T>(string section, string key, T defaultValue, string description)
+        {
+            var advancedDescription = BuildDescription(section, key, new ConfigDescription(description));
+            return Config.Bind(section, key, defaultValue, advancedDescription);
+        }
+
+        private ConfigEntry<T> Bind<T>(string section, string key, T defaultValue, ConfigDescription description)
+        {
+            var advancedDescription = BuildDescription(section, key, description);
+            return Config.Bind(section, key, defaultValue, advancedDescription);
+        }
+
+        private static ConfigDescription BuildDescription(string section, string key, ConfigDescription description)
+        {
+            bool isAdvanced = !BasicSettings.Contains($"{section}|{key}");
+            var tags = (description?.Tags ?? Array.Empty<object>())
+                .Where(tag => tag?.GetType().Name != nameof(ConfigurationManagerAttributes))
+                .ToList();
+
+            tags.Add(new ConfigurationManagerAttributes { IsAdvanced = isAdvanced });
+
+            return new ConfigDescription(
+                description?.Description,
+                description?.AcceptableValues,
+                tags.ToArray());
+        }
+
 
         private void Awake()
         {
             Instance = this;
 
             // --- 0. Global ---
-            ModEnabled = Config.Bind("0. Global", "ModEnabled", true,
+            ModEnabled = Bind("0. Global", "ModEnabled", true,
                 "Master ON/OFF switch for the entire mod. When OFF, all effects are " +
                 "cleaned up and the game behaves as if the mod is not installed.");
-            ModToggleKey = Config.Bind("0. Global", "ModToggleKey", KeyCode.Backspace,
+            ModToggleKey = Bind("0. Global", "ModToggleKey", KeyCode.Backspace,
                 "Toggle key for master mod enable/disable.");
-            AutoSwitchReticleRenderForNvg = Config.Bind("0. Global", "AutoSwitchReticleRenderForNvg", true,
+            AutoSwitchReticleRenderForNvg = Bind("0. Global", "AutoSwitchReticleRenderForNvg", true,
                 "Automatically switch reticle CommandBuffer event based on NVG state.\n" +
                 "ON: use AfterForwardAlpha while NVG are active and AfterEverything otherwise.\n" +
                 "OFF: keep the normal path (AfterForwardAlpha) unless debug override is enabled.");
 
             // --- General ---
-            DisablePiP = Config.Bind("1. General", "DisablePiP", true,
+            DisablePiP = Bind("1. General", "DisablePiP", true,
                 "Disable Picture-in-Picture optic rendering (No-PiP mode). " +
                 "Core feature — gives identical perf between hip-fire and ADS.");
-            AutoDisableForVariableScopes = Config.Bind("1. General", "AutoDisableForVariableScopes", true,
+            AutoDisableForVariableScopes = Bind("1. General", "AutoDisableForVariableScopes", true,
                 "Automatically disable all mod effects while scoped with variable magnification optics (IsAdjustableOptic=true).\n" +
                 "Also bypasses thermal/night-vision scopes detected via ScopeData.ThermalVisionData or NightVisionData.");
-            AutoBypassNameContains = Config.Bind("1. General", "AutoBypassNameContains", "npz, PU, vomz, d-evo",
+            AutoBypassNameContains = Bind("1. General", "AutoBypassNameContains", "npz, PU, vomz, d-evo",
                 "Comma-separated list of substrings. Any scope whose object name or scope key contains one of these ");
-            ScopeWhitelistNames = Config.Bind("1. General", "ScopeWhitelistNames", "",
+            ScopeWhitelistNames = Bind("1. General", "ScopeWhitelistNames", "",
                 "Comma/semicolon/newline separated list of allowed scope keys.\n" +
                 "Primary key is derived from the object under mod_scope that does not contain mount (case-insensitive).\n" +
                 "Fallbacks: template _name, template _id, then optic object name. Empty list = whitelist ignored.");
-            ScopeWhitelistToggleEntryKey = Config.Bind("1. General", "ScopeWhitelistToggleEntryKey", KeyCode.None,
+            ScopeWhitelistToggleEntryKey = Bind("1. General", "ScopeWhitelistToggleEntryKey", KeyCode.None,
                 "When pressed while scoped, add/remove the current scope key in ScopeWhitelistNames (derived from mod_scope non-mount object).");
-            DisablePiPToggleKey = Config.Bind("1. General", "DisablePiPToggleKey", KeyCode.None,
+            DisablePiPToggleKey = Bind("1. General", "DisablePiPToggleKey", KeyCode.None,
                 "Toggle key for PiP disable.");
 
-            MakeLensesTransparent = Config.Bind("1. General", "MakeLensesTransparent", true,
+            MakeLensesTransparent = Bind("1. General", "MakeLensesTransparent", true,
                 "Hide lens surfaces (linza/backLens) while scoped so you see through the tube.");
-            LensesTransparentToggleKey = Config.Bind("1. General", "LensesTransparentToggleKey", KeyCode.None,
+            LensesTransparentToggleKey = Bind("1. General", "LensesTransparentToggleKey", KeyCode.None,
                 "Toggle key for lens transparency.");
-            BlackLensWhenUnscoped = Config.Bind("1. General", "BlackLensWhenUnscoped", true,
+            BlackLensWhenUnscoped = Bind("1. General", "BlackLensWhenUnscoped", true,
                 "When unscoping, apply a solid black opaque material to the lens instead of restoring " +
                 "the original PiP/sight material. Eliminates the reticle flash during the unscope " +
                 "transition and gives the scope a realistic dark-glass appearance when not in use.");
 
             // --- Weapon Scaling ---
-            EnableWeaponScaling = Config.Bind("2. Zoom", "EnableWeaponScaling", true,
+            EnableWeaponScaling = Bind("2. Zoom", "EnableWeaponScaling", true,
                 "Compensate weapon/arms model scale across magnification levels.\n" +
                 "Without this, zooming in (lower FOV) makes the weapon appear larger on screen.\n" +
                 "With this enabled, the weapon shrinks proportionally as you zoom in so it\n" +
                 "always occupies the same screen space at every magnification level.");
-            BaselineWeaponScale = Config.Bind("2. Zoom", "BaselineWeaponScale", 0.9624413f,
+            BaselineWeaponScale = Bind("2. Zoom", "BaselineWeaponScale", 0.9624413f,
                 new ConfigDescription(
                     "Base weapon scale applied at all FOV values before compensation.\n" +
                     "1.00 = default EFT visual scale.",
                     new AcceptableValueRange<float>(0.00f, 2.00f)));
-            WeaponScaleStrength = Config.Bind("2. Zoom", "WeaponScaleStrength", 0.2723005f,
+            WeaponScaleStrength = Bind("2. Zoom", "WeaponScaleStrength", 0.2723005f,
                 new ConfigDescription(
                     "Blends between no compensation and full inverse-FOV compensation.\n" +
                     "0.00 = no compensation, 1.00 = full compensation, values outside [0,1] over/under-compensate.",
                     new AcceptableValueRange<float>(-2.00f, 2.00f)));
 
             // --- Zoom ---
-            EnableZoom = Config.Bind("2. Zoom", "EnableZoom", true,
+            EnableZoom = Bind("2. Zoom", "EnableZoom", true,
                 "Enable scope magnification via FOV zoom.");
-            DefaultZoom = Config.Bind("2. Zoom", "DefaultZoom", 4f,
+            DefaultZoom = Bind("2. Zoom", "DefaultZoom", 4f,
                 new ConfigDescription(
                     "Default magnification when auto-detection fails (e.g. fixed scopes without zoom data).",
                     new AcceptableValueRange<float>(1f, 16f)));
-            AutoFovFromScope = Config.Bind("2. Zoom", "AutoFovFromScope", true,
+            AutoFovFromScope = Bind("2. Zoom", "AutoFovFromScope", true,
                 "Auto-detect magnification from the scope's zoom data (ScopeZoomHandler). " +
                 "Works for variable-zoom scopes. Falls back to DefaultZoom for fixed scopes.");
-            ScopedFov = Config.Bind("2. Zoom", "ScopedFov", 15f,
+            ScopedFov = Bind("2. Zoom", "ScopedFov", 15f,
                 new ConfigDescription(
                     "FOV (degrees) for FOV zoom fallback mode. Lower = more zoom. " +
                     "Used for FOV zoom.",
                     new AcceptableValueRange<float>(5f, 75f)));
-            FovAnimationDuration = Config.Bind("2. Zoom", "FovAnimationDuration", 1f,
+            FovAnimationDuration = Bind("2. Zoom", "FovAnimationDuration", 1f,
                 new ConfigDescription(
                     "Duration (seconds) of the FOV zoom-in animation when entering ADS.\n" +
                     "0 = instant snap. 0.25 = smooth quarter-second transition.\n" +
                     "Scope exit always restores FOV instantly to avoid sluggish feel.",
                     new AcceptableValueRange<float>(0f, 2f)));
 
-            ManualLodBias = Config.Bind("2. Zoom", "ManualLodBias", 4.0f,
+            ManualLodBias = Bind("2. Zoom", "ManualLodBias", 4.0f,
                 new ConfigDescription(
                     "Manual LOD bias while scoped.\n" +
                     "0 = auto (baseLodBias * magnification).\n" +
                     ">0 = force this exact value (e.g. 4.0).",
                     new AcceptableValueRange<float>(0f, 20f)));
-            ManualMaximumLodLevel = Config.Bind("2. Zoom", "ManualMaximumLodLevel", -1,
+            ManualMaximumLodLevel = Bind("2. Zoom", "ManualMaximumLodLevel", -1,
                 new ConfigDescription(
                     "Manual QualitySettings.maximumLODLevel while scoped.\n" +
                     "-1 = auto (force 0 / highest detail).\n" +
                     ">=0 = force this exact max LOD level.",
                     new AcceptableValueRange<int>(-1, 8)));
-            ManualCullingMultiplier = Config.Bind("2. Zoom", "ManualCullingMultiplier", 0.8f,
+            ManualCullingMultiplier = Bind("2. Zoom", "ManualCullingMultiplier", 0.8f,
                 new ConfigDescription(
                     "Manual multiplier for Camera.layerCullDistances while scoped.\n" +
                     "0 = auto (use magnification).\n" +
@@ -340,28 +384,28 @@ namespace PiPDisabler
             BindPerMapLodBias("Lighthouse", "Lighthouse", "Lighthouse");
             BindPerMapLodBias("StreetsOfTarkov", "Streets of Tarkov", "TarkovStreets");
             BindPerMapLodBias("GroundZero", "Ground Zero", "Sandbox", "Sandbox_high");
-            ZoomToggleKey = Config.Bind("2. Zoom", "ZoomToggleKey", KeyCode.None,
+            ZoomToggleKey = Bind("2. Zoom", "ZoomToggleKey", KeyCode.None,
                 "Toggle key for zoom (None = always on when EnableZoom is true).");
 
             // --- 4. Zeroing ---
-            EnableZeroing = Config.Bind("4. Zeroing", "EnableZeroing", true,
+            EnableZeroing = Bind("4. Zeroing", "EnableZeroing", true,
                 "Enable optic zeroing (calibration distance adjustment) via keyboard.\n" +
                 "Uses the proper EFT pathway (works with Fika).");
-            ZeroingUpKey = Config.Bind("4. Zeroing", "ZeroingUpKey", KeyCode.PageUp,
+            ZeroingUpKey = Bind("4. Zeroing", "ZeroingUpKey", KeyCode.PageUp,
                 "Key to increase zeroing distance.");
-            ZeroingDownKey = Config.Bind("4. Zeroing", "ZeroingDownKey", KeyCode.PageDown,
+            ZeroingDownKey = Bind("4. Zeroing", "ZeroingDownKey", KeyCode.PageDown,
                 "Key to decrease zeroing distance.");
 
             // --- Mesh Surgery (ON by default, Cylinder mode) ---
-            EnableMeshSurgery = Config.Bind("3. Global Mesh Surgery settings", "EnableMeshSurgery", true,
+            EnableMeshSurgery = Bind("3. Global Mesh Surgery settings", "EnableMeshSurgery", true,
                 "Enable runtime mesh cutting to bore a hole through the scope housing.");
-            MeshSurgeryToggleKey = Config.Bind("3. Global Mesh Surgery settings", "MeshSurgeryToggleKey", KeyCode.None,
+            MeshSurgeryToggleKey = Bind("3. Global Mesh Surgery settings", "MeshSurgeryToggleKey", KeyCode.None,
                 "Toggle key for mesh surgery.");
-            RestoreOnUnscope = Config.Bind("3. Global Mesh Surgery settings", "RestoreOnUnscope", true,
+            RestoreOnUnscope = Bind("3. Global Mesh Surgery settings", "RestoreOnUnscope", true,
                 "Restore original meshes when leaving scope.");
-            PlaneOffsetMeters = Config.Bind("3. Global Mesh Surgery settings", "PlaneOffsetMeters", 0.001f,
+            PlaneOffsetMeters = Bind("3. Global Mesh Surgery settings", "PlaneOffsetMeters", 0.001f,
                 "Offset applied along plane normal (meters).");
-            PlaneNormalAxis = Config.Bind("3. Global Mesh Surgery settings", "PlaneNormalAxis", "-Y",
+            PlaneNormalAxis = Bind("3. Global Mesh Surgery settings", "PlaneNormalAxis", "-Y",
                 new ConfigDescription(
                     "Which local axis to use as the cut plane normal.\n" +
                     "Auto = use backLens.forward (game default).\n" +
@@ -369,93 +413,93 @@ namespace PiPDisabler
                     "-X/-Y/-Z = force the negative of that axis.\n" +
                     "If the cut is horizontal when it should be vertical, try Z or Y.",
                     new AcceptableValueList<string>("Auto", "X", "Y", "Z", "-X", "-Y", "-Z")));
-            CutRadius = Config.Bind("3. Global Mesh Surgery settings", "CutRadius", 0f,
+            CutRadius = Bind("3. Global Mesh Surgery settings", "CutRadius", 0f,
                 new ConfigDescription(
                     "Max distance (meters) from scope center to cut. 0 = unlimited (cut all geometry).\n" +
                     "Set to e.g. 0.05 to only cut geometry near the lens opening.",
                     new AcceptableValueRange<float>(0f, 1f)));
-            ShowCutPlane = Config.Bind("3. Global Mesh Surgery settings", "ShowCutPlane", false,
+            ShowCutPlane = Bind("3. Global Mesh Surgery settings", "ShowCutPlane", false,
                 "Show green/red semi-transparent circles at the near/far cut plane positions.\n" +
                 "Use this to visualize the cut endpoints.");
-            ShowCutVolume = Config.Bind("3. Global Mesh Surgery settings", "ShowCutVolume", false,
+            ShowCutVolume = Bind("3. Global Mesh Surgery settings", "ShowCutVolume", false,
                 "Show a semi-transparent 3D tube representing the full cut volume.\n" +
                 "Visualizes the near→mid→far radius profile so you can see exactly what gets removed.");
-            CutVolumeOpacity = Config.Bind("3. Global Mesh Surgery settings", "CutVolumeOpacity", 0.49f,
+            CutVolumeOpacity = Bind("3. Global Mesh Surgery settings", "CutVolumeOpacity", 0.49f,
                 new ConfigDescription(
                     "Opacity of the 3D cut volume visualizer (0 = invisible, 1 = opaque).",
                     new AcceptableValueRange<float>(0.05f, 0.8f)));
-            CutMode = Config.Bind("3. Global Mesh Surgery settings", "CutMode", "Cylinder",
+            CutMode = Bind("3. Global Mesh Surgery settings", "CutMode", "Cylinder",
                 new ConfigDescription(
                     "Plane = flat infinite cut. Cylinder = cylindrical bore cut centered on the lens axis.\n" +
                     "Cylinder removes geometry inside a cylinder of CylinderRadius around the lens center.",
                     new AcceptableValueList<string>("Plane", "Cylinder")));
-            CylinderRadius = Config.Bind("3. Global Mesh Surgery settings", "CylinderRadius", 0.011f,
+            CylinderRadius = Bind("3. Global Mesh Surgery settings", "CylinderRadius", 0.011f,
                 new ConfigDescription(
                     "Near radius (meters) of the cylindrical/cone cut (camera side).\n" +
                     "Typical scope lens radius is ~0.01-0.02m.",
                     new AcceptableValueRange<float>(0.001f, 0.1f)));
-            MidCylinderRadius = Config.Bind("3. Global Mesh Surgery settings", "MidCylinderRadius", 0.013f,
+            MidCylinderRadius = Bind("3. Global Mesh Surgery settings", "MidCylinderRadius", 0.013f,
                 new ConfigDescription(
                     "Intermediate radius (meters) at MidCylinderPosition along the bore.\n" +
                     "0 = disabled (linear near→far interpolation).\n" +
                     ">0 = two-segment interpolation: near→mid, then mid→far.\n" +
                     "Set smaller than near/far to create a waist (hourglass). Set larger for a bulge.",
                     new AcceptableValueRange<float>(0f, 0.2f)));
-            MidCylinderPosition = Config.Bind("3. Global Mesh Surgery settings", "MidCylinderPosition", 0.28f,
+            MidCylinderPosition = Bind("3. Global Mesh Surgery settings", "MidCylinderPosition", 0.28f,
                 new ConfigDescription(
                     "Position of the mid-radius control point along the cut length (0=near, 1=far).\n" +
                     "0.5 = midpoint. 0.3 = closer to camera. 0.7 = closer to objective.",
                     new AcceptableValueRange<float>(0.01f, 0.99f)));
-            FarCylinderRadius = Config.Bind("3. Global Mesh Surgery settings", "FarCylinderRadius", 0.12f,
+            FarCylinderRadius = Bind("3. Global Mesh Surgery settings", "FarCylinderRadius", 0.12f,
                 new ConfigDescription(
                     "Far radius (meters) of the cone cut (objective side).\n" +
                     "0 = same as CylinderRadius (pure cylinder). >0 creates a cone/frustum shape.\n" +
                     "Set larger than CylinderRadius to widen the bore toward the objective lens.",
                     new AcceptableValueRange<float>(0f, 0.2f)));
-            Plane1OffsetMeters = Config.Bind("3. Global Mesh Surgery settings", "Plane1OffsetMeters", 0f,
+            Plane1OffsetMeters = Bind("3. Global Mesh Surgery settings", "Plane1OffsetMeters", 0f,
                 new ConfigDescription(
                     "Offset (meters) for plane 1 from linza/backLens origin along bore axis.\n" +
                     "Plane 1 radius is always CylinderRadius.",
                     new AcceptableValueRange<float>(-0.02f, 0.02f)));
-            Plane2Position = Config.Bind("3. Global Mesh Surgery settings", "Plane2Position", 0.1138498f,
+            Plane2Position = Bind("3. Global Mesh Surgery settings", "Plane2Position", 0.1138498f,
                 new ConfigDescription(
                     "Plane 2 profile position (0..1) anchored from the near side.\n" +
                     "Changing CutLength keeps this plane at the same world-space depth from near.",
                     new AcceptableValueRange<float>(0f, 1f)));
-            Plane2Radius = Config.Bind("3. Global Mesh Surgery settings", "Plane2Radius", 0.0186338f,
+            Plane2Radius = Bind("3. Global Mesh Surgery settings", "Plane2Radius", 0.0186338f,
                 new ConfigDescription(
                     "Radius (meters) at plane 2.",
                     new AcceptableValueRange<float>(0f, 0.2f)));
-            Plane3Position = Config.Bind("3. Global Mesh Surgery settings", "Plane3Position", 0.55f,
+            Plane3Position = Bind("3. Global Mesh Surgery settings", "Plane3Position", 0.55f,
                 new ConfigDescription(
                     "Normalized depth of plane 3 from near (0) to far (1).",
                     new AcceptableValueRange<float>(0f, 1f)));
-            Plane3Radius = Config.Bind("3. Global Mesh Surgery settings", "Plane3Radius", 0.2f,
+            Plane3Radius = Bind("3. Global Mesh Surgery settings", "Plane3Radius", 0.2f,
                 new ConfigDescription(
                     "Radius (meters) at plane 3.",
                     new AcceptableValueRange<float>(0f, 0.2f)));
-            Plane4Position = Config.Bind("3. Global Mesh Surgery settings", "Plane4Position", 1f,
+            Plane4Position = Bind("3. Global Mesh Surgery settings", "Plane4Position", 1f,
                 new ConfigDescription(
                     "Normalized depth of plane 4 from near (0) to far (1). Usually 1.",
                     new AcceptableValueRange<float>(0f, 1f)));
-            Plane4Radius = Config.Bind("3. Global Mesh Surgery settings", "Plane4Radius", 0.2f,
+            Plane4Radius = Bind("3. Global Mesh Surgery settings", "Plane4Radius", 0.2f,
                 new ConfigDescription(
                     "Radius (meters) at plane 4 (away from player).",
                     new AcceptableValueRange<float>(0f, 0.2f)));
-            CutStartOffset = Config.Bind("3. Global Mesh Surgery settings", "CutStartOffset", 0.04084507f,
+            CutStartOffset = Bind("3. Global Mesh Surgery settings", "CutStartOffset", 0.04084507f,
                 new ConfigDescription(
                     "How far behind the backLens (toward the camera) the near cut plane starts.\n" +
                     "The near plane is fixed at: backLens - (offset × boreAxis).\n" +
                     "0 = starts exactly at the backLens. 0.05 = 5cm behind it (catches interior tube geometry).\n" +
                     "Changing CutLength does NOT move this plane.",
                     new AcceptableValueRange<float>(0f, 0.3f)));
-            CutLength = Config.Bind("3. Global Mesh Surgery settings", "CutLength", 0.755493f,
+            CutLength = Bind("3. Global Mesh Surgery settings", "CutLength", 0.755493f,
                 new ConfigDescription(
                     "How far forward from the near plane the cut extends (toward the objective).\n" +
                     "The far plane is at: nearPlane + (length × boreAxis).\n" +
                     "Only the far plane moves when you change this value.",
                     new AcceptableValueRange<float>(0.01f, 1f)));
-            NearPreserveDepth = Config.Bind("3. Global Mesh Surgery settings", "NearPreserveDepth", 0.02549295f,
+            NearPreserveDepth = Bind("3. Global Mesh Surgery settings", "NearPreserveDepth", 0.02549295f,
                 new ConfigDescription(
                     "Depth (meters) from the near cut plane where NO geometry is cut.\n" +
                     "Preserves the eyepiece housing closest to the camera so you\n" +
@@ -463,111 +507,111 @@ namespace PiPDisabler
                     "0.01 = 1cm ring (default). 0.02-0.04 = thicker ring.\n" +
                     "0 = disabled (cut starts at the near plane — removes everything).",
                     new AcceptableValueRange<float>(0f, 0.15f)));
-            ShowReticle = Config.Bind("3. Global Mesh Surgery settings", "ShowReticle", true,
+            ShowReticle = Bind("3. Global Mesh Surgery settings", "ShowReticle", true,
                 "Render the scope reticle texture as a glowing overlay where the lens was.\n" +
                 "Uses alpha blending so the reticle's own alpha channel controls transparency.");
-            ReticleBaseSize = Config.Bind("3. Global Mesh Surgery settings", "ReticleBaseSize", 0.030f,
+            ReticleBaseSize = Bind("3. Global Mesh Surgery settings", "ReticleBaseSize", 0.030f,
                 new ConfigDescription(
                     "Physical diameter (meters) of the reticle quad at 1x magnification.\n" +
                     "The quad is scaled by 1/magnification so screen-pixel coverage stays constant\n" +
                     "across all zoom levels.  Typical scope lens diameter is 0.02-0.04 m.\n" +
                     "Set to 0 to fall back to the legacy CylinderRadius x2 value.",
                     new AcceptableValueRange<float>(0f, 0.2f)));
-            ExpandSearchToWeaponRoot = Config.Bind("3. Global Mesh Surgery settings", "ExpandSearchToWeaponRoot", true,
+            ExpandSearchToWeaponRoot = Bind("3. Global Mesh Surgery settings", "ExpandSearchToWeaponRoot", true,
                 "Expand the mesh surgery search root all the way up to the Weapon_root node.\n" +
                 "When enabled, meshes on the weapon body under Weapon_root are also candidates\n" +
                 "for cutting — not just those in the scope sub-hierarchy.\n" +
                 "Use this when scope geometry blends into the weapon receiver and you need to cut\n" +
                 "the underlying weapon meshes as well.\n" +
                 "Example path: Weapon_root/Weapon_root_anim/weapon/mod_scope/...");
-            DebugShowHousingMask = Config.Bind("3. Global Mesh Surgery settings", "DebugShowHousingMask", false,
+            DebugShowHousingMask = Bind("3. Global Mesh Surgery settings", "DebugShowHousingMask", false,
                 "Render a red/yellow overlay wherever the scope housing stencil mask is\n" +
                 "suppressing the reticle.  Use this to diagnose which meshes are incorrectly\n" +
                 "masking the aperture.  Combine with the BepInEx log to see the exact renderer\n" +
                 "names printed by CollectHousingRenderers.  Disable in normal play.");
-            StencilIncludeWeaponMeshes = Config.Bind("3. Global Mesh Surgery settings", "StencilIncludeWeaponMeshes", true,
+            StencilIncludeWeaponMeshes = Bind("3. Global Mesh Surgery settings", "StencilIncludeWeaponMeshes", true,
                 "Include weapon body renderers (found under the 'weapon' transform) in the\n" +
                 "stencil mask alongside the scope housing.  Prevents the reticle from\n" +
                 "bleeding through the weapon mesh at screen centre.");
 
             // --- Custom Mesh Surgery settings ---
-            SaveCustomMeshSurgerySettingsKey = Config.Bind("4. Custom Mesh Surgery settings", "SaveCustomMeshSurgerySettingsKey", KeyCode.None,
+            SaveCustomMeshSurgerySettingsKey = Bind("4. Custom Mesh Surgery settings", "SaveCustomMeshSurgerySettingsKey", KeyCode.None,
                 "When pressed while scoped, save all values from this category for the active scope key into custom_mesh_surgery_settings.json.");
-            DeleteCustomMeshSurgerySettingsKey = Config.Bind("4. Custom Mesh Surgery settings", "DeleteCustomMeshSurgerySettingsKey", KeyCode.None,
+            DeleteCustomMeshSurgerySettingsKey = Bind("4. Custom Mesh Surgery settings", "DeleteCustomMeshSurgerySettingsKey", KeyCode.None,
                 "When pressed while scoped, delete custom mesh surgery settings for the active scope key from custom_mesh_surgery_settings.json.");
-            CustomPlaneOffsetMeters = Config.Bind("4. Custom Mesh Surgery settings", "PlaneOffsetMeters", 0.001f, "Custom per-scope plane offset applied along plane normal (meters).");
-            CustomPlaneNormalAxis = Config.Bind("4. Custom Mesh Surgery settings", "PlaneNormalAxis", "-Y", new ConfigDescription("Custom per-scope local axis for the cut plane normal.", new AcceptableValueList<string>("Auto", "X", "Y", "Z", "-X", "-Y", "-Z")));
-            CustomCutRadius = Config.Bind("4. Custom Mesh Surgery settings", "CutRadius", 0f, new ConfigDescription("Custom per-scope max cut distance in meters (0 = unlimited).", new AcceptableValueRange<float>(0f, 1f)));
-            CustomShowCutPlane = Config.Bind("4. Custom Mesh Surgery settings", "ShowCutPlane", false, "Custom per-scope cut plane visualizer toggle.");
-            CustomShowCutVolume = Config.Bind("4. Custom Mesh Surgery settings", "ShowCutVolume", false, "Custom per-scope cut volume visualizer toggle.");
-            CustomCutVolumeOpacity = Config.Bind("4. Custom Mesh Surgery settings", "CutVolumeOpacity", 0.49f, new ConfigDescription("Custom per-scope cut volume opacity.", new AcceptableValueRange<float>(0.05f, 0.8f)));
-            CustomCutMode = Config.Bind("4. Custom Mesh Surgery settings", "CutMode", "Cylinder", new ConfigDescription("Custom per-scope mesh cut mode.", new AcceptableValueList<string>("Plane", "Cylinder")));
-            CustomCylinderRadius = Config.Bind("4. Custom Mesh Surgery settings", "CylinderRadius", 0.011f, new ConfigDescription("Custom per-scope near radius in meters.", new AcceptableValueRange<float>(0.001f, 0.1f)));
-            CustomMidCylinderRadius = Config.Bind("4. Custom Mesh Surgery settings", "MidCylinderRadius", 0.013f, new ConfigDescription("Custom per-scope mid profile radius in meters.", new AcceptableValueRange<float>(0f, 0.2f)));
-            CustomMidCylinderPosition = Config.Bind("4. Custom Mesh Surgery settings", "MidCylinderPosition", 0.28f, new ConfigDescription("Custom per-scope mid profile position (0..1).", new AcceptableValueRange<float>(0.01f, 0.99f)));
-            CustomFarCylinderRadius = Config.Bind("4. Custom Mesh Surgery settings", "FarCylinderRadius", 0.12f, new ConfigDescription("Custom per-scope far radius in meters.", new AcceptableValueRange<float>(0f, 0.2f)));
-            CustomPlane1OffsetMeters = Config.Bind("4. Custom Mesh Surgery settings", "Plane1OffsetMeters", 0f, new ConfigDescription("Custom per-scope plane 1 offset in meters.", new AcceptableValueRange<float>(-0.02f, 0.02f)));
-            CustomPlane2Position = Config.Bind("4. Custom Mesh Surgery settings", "Plane2Position", 0.1138498f, new ConfigDescription("Custom per-scope plane 2 position (0..1), anchored from near when CutLength changes.", new AcceptableValueRange<float>(0f, 1f)));
-            CustomPlane2Radius = Config.Bind("4. Custom Mesh Surgery settings", "Plane2Radius", 0.0186338f, new ConfigDescription("Custom per-scope plane 2 radius in meters.", new AcceptableValueRange<float>(0f, 0.2f)));
-            CustomPlane3Position = Config.Bind("4. Custom Mesh Surgery settings", "Plane3Position", 0.55f, new ConfigDescription("Custom per-scope plane 3 depth (0..1).", new AcceptableValueRange<float>(0f, 1f)));
-            CustomPlane3Radius = Config.Bind("4. Custom Mesh Surgery settings", "Plane3Radius", 0.2f, new ConfigDescription("Custom per-scope plane 3 radius in meters.", new AcceptableValueRange<float>(0f, 0.2f)));
-            CustomPlane4Position = Config.Bind("4. Custom Mesh Surgery settings", "Plane4Position", 1f, new ConfigDescription("Custom per-scope plane 4 depth (0..1).", new AcceptableValueRange<float>(0f, 1f)));
-            CustomPlane4Radius = Config.Bind("4. Custom Mesh Surgery settings", "Plane4Radius", 0.2f, new ConfigDescription("Custom per-scope plane 4 radius in meters.", new AcceptableValueRange<float>(0f, 0.2f)));
-            CustomCutStartOffset = Config.Bind("4. Custom Mesh Surgery settings", "CutStartOffset", 0.04084507f, new ConfigDescription("Custom per-scope cut start offset in meters.", new AcceptableValueRange<float>(-0.2f, 0.2f)));
-            CustomCutLength = Config.Bind("4. Custom Mesh Surgery settings", "CutLength", 0.755493f, new ConfigDescription("Custom per-scope cut length in meters.", new AcceptableValueRange<float>(0.01f, 4f)));
-            CustomNearPreserveDepth = Config.Bind("4. Custom Mesh Surgery settings", "NearPreserveDepth", 0.02549295f, new ConfigDescription("Custom per-scope near preserve depth in meters.", new AcceptableValueRange<float>(0f, 0.2f)));
-            CustomShowReticle = Config.Bind("4. Custom Mesh Surgery settings", "ShowReticle", true, "Custom per-scope reticle visibility.");
-            CustomReticleBaseSize = Config.Bind("4. Custom Mesh Surgery settings", "ReticleBaseSize", 0.030f, new ConfigDescription("Custom per-scope reticle base diameter in meters.", new AcceptableValueRange<float>(0f, 0.2f)));
-            CustomRestoreOnUnscope = Config.Bind("4. Custom Mesh Surgery settings", "RestoreOnUnscope", true, "Custom per-scope restore behavior when leaving scope.");
-            CustomExpandSearchToWeaponRoot = Config.Bind("4. Custom Mesh Surgery settings", "ExpandSearchToWeaponRoot", true, "Custom per-scope search root expansion to Weapon_root.");
+            CustomPlaneOffsetMeters = Bind("4. Custom Mesh Surgery settings", "PlaneOffsetMeters", 0.001f, "Custom per-scope plane offset applied along plane normal (meters).");
+            CustomPlaneNormalAxis = Bind("4. Custom Mesh Surgery settings", "PlaneNormalAxis", "-Y", new ConfigDescription("Custom per-scope local axis for the cut plane normal.", new AcceptableValueList<string>("Auto", "X", "Y", "Z", "-X", "-Y", "-Z")));
+            CustomCutRadius = Bind("4. Custom Mesh Surgery settings", "CutRadius", 0f, new ConfigDescription("Custom per-scope max cut distance in meters (0 = unlimited).", new AcceptableValueRange<float>(0f, 1f)));
+            CustomShowCutPlane = Bind("4. Custom Mesh Surgery settings", "ShowCutPlane", false, "Custom per-scope cut plane visualizer toggle.");
+            CustomShowCutVolume = Bind("4. Custom Mesh Surgery settings", "ShowCutVolume", false, "Custom per-scope cut volume visualizer toggle.");
+            CustomCutVolumeOpacity = Bind("4. Custom Mesh Surgery settings", "CutVolumeOpacity", 0.49f, new ConfigDescription("Custom per-scope cut volume opacity.", new AcceptableValueRange<float>(0.05f, 0.8f)));
+            CustomCutMode = Bind("4. Custom Mesh Surgery settings", "CutMode", "Cylinder", new ConfigDescription("Custom per-scope mesh cut mode.", new AcceptableValueList<string>("Plane", "Cylinder")));
+            CustomCylinderRadius = Bind("4. Custom Mesh Surgery settings", "CylinderRadius", 0.011f, new ConfigDescription("Custom per-scope near radius in meters.", new AcceptableValueRange<float>(0.001f, 0.1f)));
+            CustomMidCylinderRadius = Bind("4. Custom Mesh Surgery settings", "MidCylinderRadius", 0.013f, new ConfigDescription("Custom per-scope mid profile radius in meters.", new AcceptableValueRange<float>(0f, 0.2f)));
+            CustomMidCylinderPosition = Bind("4. Custom Mesh Surgery settings", "MidCylinderPosition", 0.28f, new ConfigDescription("Custom per-scope mid profile position (0..1).", new AcceptableValueRange<float>(0.01f, 0.99f)));
+            CustomFarCylinderRadius = Bind("4. Custom Mesh Surgery settings", "FarCylinderRadius", 0.12f, new ConfigDescription("Custom per-scope far radius in meters.", new AcceptableValueRange<float>(0f, 0.2f)));
+            CustomPlane1OffsetMeters = Bind("4. Custom Mesh Surgery settings", "Plane1OffsetMeters", 0f, new ConfigDescription("Custom per-scope plane 1 offset in meters.", new AcceptableValueRange<float>(-0.02f, 0.02f)));
+            CustomPlane2Position = Bind("4. Custom Mesh Surgery settings", "Plane2Position", 0.1138498f, new ConfigDescription("Custom per-scope plane 2 position (0..1), anchored from near when CutLength changes.", new AcceptableValueRange<float>(0f, 1f)));
+            CustomPlane2Radius = Bind("4. Custom Mesh Surgery settings", "Plane2Radius", 0.0186338f, new ConfigDescription("Custom per-scope plane 2 radius in meters.", new AcceptableValueRange<float>(0f, 0.2f)));
+            CustomPlane3Position = Bind("4. Custom Mesh Surgery settings", "Plane3Position", 0.55f, new ConfigDescription("Custom per-scope plane 3 depth (0..1).", new AcceptableValueRange<float>(0f, 1f)));
+            CustomPlane3Radius = Bind("4. Custom Mesh Surgery settings", "Plane3Radius", 0.2f, new ConfigDescription("Custom per-scope plane 3 radius in meters.", new AcceptableValueRange<float>(0f, 0.2f)));
+            CustomPlane4Position = Bind("4. Custom Mesh Surgery settings", "Plane4Position", 1f, new ConfigDescription("Custom per-scope plane 4 depth (0..1).", new AcceptableValueRange<float>(0f, 1f)));
+            CustomPlane4Radius = Bind("4. Custom Mesh Surgery settings", "Plane4Radius", 0.2f, new ConfigDescription("Custom per-scope plane 4 radius in meters.", new AcceptableValueRange<float>(0f, 0.2f)));
+            CustomCutStartOffset = Bind("4. Custom Mesh Surgery settings", "CutStartOffset", 0.04084507f, new ConfigDescription("Custom per-scope cut start offset in meters.", new AcceptableValueRange<float>(-0.2f, 0.2f)));
+            CustomCutLength = Bind("4. Custom Mesh Surgery settings", "CutLength", 0.755493f, new ConfigDescription("Custom per-scope cut length in meters.", new AcceptableValueRange<float>(0.01f, 4f)));
+            CustomNearPreserveDepth = Bind("4. Custom Mesh Surgery settings", "NearPreserveDepth", 0.02549295f, new ConfigDescription("Custom per-scope near preserve depth in meters.", new AcceptableValueRange<float>(0f, 0.2f)));
+            CustomShowReticle = Bind("4. Custom Mesh Surgery settings", "ShowReticle", true, "Custom per-scope reticle visibility.");
+            CustomReticleBaseSize = Bind("4. Custom Mesh Surgery settings", "ReticleBaseSize", 0.030f, new ConfigDescription("Custom per-scope reticle base diameter in meters.", new AcceptableValueRange<float>(0f, 0.2f)));
+            CustomRestoreOnUnscope = Bind("4. Custom Mesh Surgery settings", "RestoreOnUnscope", true, "Custom per-scope restore behavior when leaving scope.");
+            CustomExpandSearchToWeaponRoot = Bind("4. Custom Mesh Surgery settings", "ExpandSearchToWeaponRoot", true, "Custom per-scope search root expansion to Weapon_root.");
 
             // --- Scope Effects ---
-            VignetteEnabled = Config.Bind("5. Scope Effects", "VignetteEnabled", true,
+            VignetteEnabled = Bind("5. Scope Effects", "VignetteEnabled", true,
                 "Render a circular vignette ring around the scope aperture.\n" +
                 "A world-space quad at the lens position fading from transparent centre to black edge.");
-            VignetteOpacity = Config.Bind("5. Scope Effects", "VignetteOpacity", 0.39f,
+            VignetteOpacity = Bind("5. Scope Effects", "VignetteOpacity", 0.39f,
                 new ConfigDescription("Maximum opacity of the lens vignette ring (0=invisible, 1=full black).",
                     new AcceptableValueRange<float>(0f, 1f)));
-            VignetteSizeMult = Config.Bind("5. Scope Effects", "VignetteSizeMult", 0.35f,
+            VignetteSizeMult = Bind("5. Scope Effects", "VignetteSizeMult", 0.35f,
                 new ConfigDescription(
                     "Vignette quad diameter as a multiplier of ReticleBaseSize.\n" +
                     "1.0 = same size as reticle.  1.5 gives a visible border ring.\n" +
                     "Higher values (5-15) may be needed for high-magnification scopes.",
                     new AcceptableValueRange<float>(0f, 1f)));
-            VignetteSoftness = Config.Bind("5. Scope Effects", "VignetteSoftness", 0.51f,
+            VignetteSoftness = Bind("5. Scope Effects", "VignetteSoftness", 0.51f,
                 new ConfigDescription(
                     "Fraction of the vignette radius used for the gradient falloff (0=hard edge, 1=full gradient).",
                     new AcceptableValueRange<float>(0f, 1f)));
 
-            ScopeShadowEnabled = Config.Bind("5. Scope Effects", "ScopeShadowEnabled", true,
+            ScopeShadowEnabled = Bind("5. Scope Effects", "ScopeShadowEnabled", true,
                 "Overlay a fullscreen scope-tube shadow: black everywhere except a transparent\n" +
                 "circular window in the centre.  Simulates looking down a scope tube.");
-            ScopeShadowOpacity = Config.Bind("5. Scope Effects", "ScopeShadowOpacity", 0.75f,
+            ScopeShadowOpacity = Bind("5. Scope Effects", "ScopeShadowOpacity", 0.75f,
                 new ConfigDescription("Maximum opacity of the scope shadow overlay.",
                     new AcceptableValueRange<float>(0f, 1f)));
-            ScopeShadowRadius = Config.Bind("5. Scope Effects", "ScopeShadowRadius", 0.07859156f,
+            ScopeShadowRadius = Bind("5. Scope Effects", "ScopeShadowRadius", 0.07859156f,
                 new ConfigDescription(
                     "Radius of the transparent centre window as a fraction of the half-screen (0.0-0.5).\n" +
                     "0.18 = window fills roughly 36% of screen width.  Increase for wider aperture.",
                     new AcceptableValueRange<float>(0.02f, 0.5f)));
-            ScopeShadowSoftness = Config.Bind("5. Scope Effects", "ScopeShadowSoftness", 0.08535211f,
+            ScopeShadowSoftness = Bind("5. Scope Effects", "ScopeShadowSoftness", 0.08535211f,
                 new ConfigDescription(
                     "Width of the gradient edge between the clear window and the black shadow (fraction of screen).\n" +
                     "0 = hard edge.  0.05-0.1 is a natural-looking falloff.",
                     new AcceptableValueRange<float>(0f, 0.3f)));
 
             // --- Diagnostics ---
-            DiagnosticsKey = Config.Bind("6. Diagnostics", "DiagnosticsKey", KeyCode.None,
+            DiagnosticsKey = Bind("6. Diagnostics", "DiagnosticsKey", KeyCode.None,
                 "Press to log full diagnostics for the currently active scope: name, hierarchy,\n" +
                 "magnification and cut-plane config.");
 
             // --- Debug ---
-            VerboseLogging = Config.Bind("7. Debug", "VerboseLogging", false,
+            VerboseLogging = Bind("7. Debug", "VerboseLogging", false,
                 "Enable detailed logging. Turn on to diagnose lens/zoom issues.");
-            DebugLogCutCandidates = Config.Bind("7. Debug", "DebugLogCutCandidates", false,
+            DebugLogCutCandidates = Bind("7. Debug", "DebugLogCutCandidates", false,
                 "When enabled, logs every mesh candidate found by mesh surgery (path, mesh name, vertices, active state), " +
                 "plus per-candidate radius checks. Useful to diagnose attachments that are not being cut.");
-            DebugReticleAfterEverything = Config.Bind("7. Debug", "DebugReticleAfterEverything", false,
+            DebugReticleAfterEverything = Bind("7. Debug", "DebugReticleAfterEverything", false,
                 "Debug toggle for reticle CommandBuffer event. False = AfterForwardAlpha (default, NVG-friendly). " +
                 "True = AfterEverything (late overlay testing). ");
 
@@ -828,7 +872,7 @@ namespace PiPDisabler
             if (locationIds == null || locationIds.Length == 0 || string.IsNullOrWhiteSpace(configKeySuffix))
                 return;
 
-            var entry = Config.Bind("2. Zoom Per-Map", $"ManualLodBias_{configKeySuffix}", ManualLodBias.Value,
+            var entry = Bind("2. Zoom Per-Map", $"ManualLodBias_{configKeySuffix}", ManualLodBias.Value,
                 new ConfigDescription(
                     $"Manual LOD bias override while scoped on map '{mapDisplayName}'.\n" +
                     "0 = auto (baseLodBias * magnification).\n" +


### PR DESCRIPTION
### Motivation
- Reduce config UI clutter by marking most configuration entries as advanced while keeping a small, user-facing subset visible by default.
- Provide a single, consistent place to control which settings are promoted to basic vs advanced so future additions inherit the behavior automatically.

### Description
- Added a `BasicSettings` allowlist and a small `ConfigurationManagerAttributes` helper type, and treat every config entry as advanced unless it appears in the allowlist. 
- Introduced `Bind<T>(...)` wrappers and `BuildDescription(...)` to inject `ConfigurationManagerAttributes.IsAdvanced` into every `ConfigDescription` while preserving existing descriptions, acceptable ranges and tags. 
- Replaced direct `Config.Bind(...)` calls with the new `Bind(...)` wrapper across `PiPDisablerPlugin.cs` so all current and future bindings honor the new advanced/default behavior. 
- Added `using System.Linq;` for tag filtering logic.

### Testing
- Ran repository searches to validate replacements (`rg`/`sed`) and verified `PiPDisablerPlugin.cs` updated and committed successfully. 
- Attempted to run `dotnet build -v minimal` but the environment lacks `dotnet`, so a build could not be performed here (`bash: command not found: dotnet`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7da165fe0832882f4bf3ec006d942)