### PR TITLE
Add freelook FOV & mesh restoration patch

### DIFF
--- a/Patches/FreelookFOVpatch.cs
+++ b/Patches/FreelookFOVpatch.cs
@@ -1,0 +1,96 @@
+using System.Reflection;
+using EFT;
+using EFT.CameraControl;
+using HarmonyLib;
+using SPT.Reflection.Patching;
+
+namespace PiPDisabler.Patches
+{
+    /// <summary>
+    /// Keeps scoped FOV stable while ADS freelook is active and temporarily
+    /// restores uncut meshes to avoid clipping while looking around.
+    /// </summary>
+    internal sealed class FreelookFOVpatch : ModulePatch
+    {
+        private static bool _freelookActive;
+        private static float _cachedScopeFov;
+        private static OpticSight _cachedOptic;
+
+        protected override MethodBase GetTargetMethod()
+            => AccessTools.Method(typeof(Player), nameof(Player.Look),
+                new[] { typeof(float), typeof(float), typeof(bool) });
+
+        [PatchPrefix]
+        private static void Prefix(Player __instance, ref bool __state)
+        {
+            __state = __instance != null && __instance.MouseLookControl;
+        }
+
+        [PatchPostfix]
+        private static void Postfix(Player __instance, bool __state)
+        {
+            if (__instance == null)
+            {
+                ResetState();
+                return;
+            }
+
+            bool isFreelookNow = __instance.MouseLookControl;
+            bool enteredFreelook = !__state && isFreelookNow;
+            bool exitedFreelook = __state && !isFreelookNow;
+
+            bool scopedAndAiming = ScopeLifecycle.IsScoped
+                                   && !ScopeLifecycle.IsModBypassedForCurrentScope
+                                   && __instance.ProceduralWeaponAnimation != null
+                                   && __instance.ProceduralWeaponAnimation.IsAiming;
+
+            if (!scopedAndAiming)
+            {
+                if (_freelookActive)
+                    ResetState();
+                return;
+            }
+
+            var activeOptic = ScopeLifecycle.ActiveOptic;
+            if (activeOptic == null)
+            {
+                return;
+            }
+
+            if (enteredFreelook)
+            {
+                _freelookActive = true;
+                _cachedOptic = activeOptic;
+
+                if (CameraClass.Exist && CameraClass.Instance != null)
+                    _cachedScopeFov = CameraClass.Instance.Fov;
+
+                if (PiPDisablerPlugin.EnableMeshSurgery.Value)
+                    MeshSurgeryManager.RestoreForScope(activeOptic.transform);
+            }
+
+            if (exitedFreelook && _freelookActive)
+            {
+                if (CameraClass.Exist && CameraClass.Instance != null && _cachedScopeFov > 0.1f)
+                    CameraClass.Instance.SetFov(_cachedScopeFov, 0.05f, true);
+
+                if (PiPDisablerPlugin.EnableMeshSurgery.Value)
+                {
+                    if (_cachedOptic != null)
+                        MeshSurgeryManager.ApplyForOptic(_cachedOptic);
+                    else
+                        MeshSurgeryManager.ApplyForOptic(activeOptic);
+                }
+
+                ResetState();
+            }
+        }
+
+        private static void ResetState()
+        {
+            _freelookActive = false;
+            _cachedScopeFov = 0f;
+            _cachedOptic = null;
+        }
+    }
+}

--- a/Patches/Patcher.cs
+++ b/Patches/Patcher.cs
@@ -21,6 +21,7 @@ namespace PiPDisabler.Patches
             SafeEnable<PiPDisabler.OpticSightLensFade_NoPipPatch>();
             // FOV zoom
             SafeEnable<PWAMethod23Patch>();
+            SafeEnable<FreelookFOVpatch>();
             // Weapon scaling (freeze ribcage scale while scoped)
             SafeEnable<WeaponScalingPatch>();
             // Fika compatibility patch


### PR DESCRIPTION
### Motivation
- Prevent visual clipping and FOV glitches when the player enters ADS freelook by caching the scoped FOV and temporarily restoring uncut meshes while freelooking.

### Description
- Add `Patches/FreelookFOVpatch.cs`, a Harmony `ModulePatch` that hooks `Player.Look(float,float,bool)` to detect freelook enter/exit and track `MouseLookControl` state.
- On freelook enter while scoped and aiming the patch caches the current `CameraClass.Instance.Fov` and calls `MeshSurgeryManager.RestoreForScope(activeOptic.transform)` to restore uncut meshes.
- On freelook exit the patch restores the cached scope FOV via `CameraClass.Instance.SetFov(...)` and reapplies mesh cutting with `MeshSurgeryManager.ApplyForOptic(...)` for the previously active optic.
- Register the new patch in `Patches/Patcher.cs` so it is enabled with the other patches.

### Testing
- Attempted to build with `dotnet build` (`dotnet build -v minimal`) but the environment lacks the SDK so the build could not be executed (error: `bash: command not found: dotnet`).
- No automated unit tests were run in this environment due to the missing `dotnet` toolchain.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7d9ee01c48328943e781b7589695b)