### PR TITLE
Reorder config surface and hardcode non-essential settings

### DIFF
--- a/Patches/CameraSettingsManager.cs
+++ b/Patches/CameraSettingsManager.cs
@@ -95,9 +95,7 @@ namespace PiPDisabler
             QualitySettings.lodBias = newLodBias;
 
             // Force highest LOD by default unless overridden by manual max LOD level.
-            int manualMaxLod = PiPDisablerPlugin.ManualMaximumLodLevel != null
-                ? PiPDisablerPlugin.ManualMaximumLodLevel.Value
-                : -1;
+            int manualMaxLod = PiPDisablerPlugin.ManualMaximumLodLevel;
             int appliedMaxLod = manualMaxLod >= 0 ? manualMaxLod : 0;
             QualitySettings.maximumLODLevel = appliedMaxLod;
 
@@ -109,9 +107,7 @@ namespace PiPDisabler
             // Increase cull distances proportionally so objects stay visible when zoomed
             if (_savedCullDistances != null)
             {
-                float manualCullMultiplier = PiPDisablerPlugin.ManualCullingMultiplier != null
-                    ? PiPDisablerPlugin.ManualCullingMultiplier.Value
-                    : 0f;
+                float manualCullMultiplier = PiPDisablerPlugin.ManualCullingMultiplier;
                 float cullingMultiplier = manualCullMultiplier > 0f
                     ? manualCullMultiplier
                     : Mathf.Max(magnification, 1f);

--- a/Patches/FikaCompat.cs
+++ b/Patches/FikaCompat.cs
@@ -57,7 +57,7 @@ namespace PiPDisabler.Patches
             if (!PiPDisablerPlugin.ModEnabled.Value)
                 return true;
 
-            if (!PiPDisablerPlugin.DisablePiP.Value)
+            if (!PiPDisablerPlugin.DisablePiP)
                 return true;
 
             if (!ScopeLifecycle.IsScoped)

--- a/Patches/FovController.cs
+++ b/Patches/FovController.cs
@@ -71,8 +71,8 @@ namespace PiPDisabler
         /// </summary>
         public static float ComputeZoomedFov()
         {
-            if (!PiPDisablerPlugin.AutoFovFromScope.Value)
-                return PiPDisablerPlugin.ScopedFov.Value;
+            if (!PiPDisablerPlugin.AutoFovFromScope)
+                return PiPDisablerPlugin.ScopedFov;
 
             float magnification = GetEffectiveMagnification();
             if (magnification > 0.1f)
@@ -92,7 +92,7 @@ namespace PiPDisabler
                 return resultFov;
             }
 
-            return PiPDisablerPlugin.ScopedFov.Value;
+            return PiPDisablerPlugin.ScopedFov;
         }
 
         /// <summary>
@@ -134,7 +134,7 @@ namespace PiPDisabler
 
             // 3. Config default
             _lastLoggedSource = "DEFAULT";
-            return PiPDisablerPlugin.DefaultZoom.Value;
+            return PiPDisablerPlugin.DefaultZoom;
         }
 
         /// <summary>

--- a/Patches/FreelookTracker.cs
+++ b/Patches/FreelookTracker.cs
@@ -176,7 +176,7 @@ namespace PiPDisabler
             //  - The game is trying to set a non-freelook FOV (i.e. freelook just ended
             //    and EFT wants to set 35° — we know because targetFov < settingsFov)
             if (PiPDisablerPlugin.ModEnabled.Value &&
-                PiPDisablerPlugin.EnableZoom.Value &&
+                PiPDisablerPlugin.EnableZoom &&
                 ScopeLifecycle.IsScoped &&
                 !ScopeLifecycle.IsModBypassedForCurrentScope &&
                 _lastAppliedScopedFov > 0.5f)

--- a/Patches/LensTransparency.cs
+++ b/Patches/LensTransparency.cs
@@ -156,8 +156,8 @@ namespace PiPDisabler
         {
             if (os == null) return;
 
-            bool shouldHide = PiPDisablerPlugin.MakeLensesTransparent.Value
-                              || PiPDisablerPlugin.DisablePiP.Value;
+            bool shouldHide = PiPDisablerPlugin.MakeLensesTransparent
+                              || PiPDisablerPlugin.DisablePiP;
             if (!shouldHide) return;
 
             Transform searchRoot = FindScopeSearchRoot(os.transform);
@@ -255,8 +255,7 @@ namespace PiPDisabler
         {
             if (_hidden.Count == 0) return;
 
-            bool blackLens = PiPDisablerPlugin.BlackLensWhenUnscoped != null
-                             && PiPDisablerPlugin.BlackLensWhenUnscoped.Value;
+            bool blackLens = PiPDisablerPlugin.BlackLensWhenUnscoped;
 
             for (int i = 0; i < _hidden.Count; i++)
             {

--- a/Patches/PWAMethod23Patch.cs
+++ b/Patches/PWAMethod23Patch.cs
@@ -57,7 +57,7 @@ namespace PiPDisabler.Patches
 
             if (pwa != null &&
                 PiPDisablerPlugin.ModEnabled.Value &&
-                PiPDisablerPlugin.EnableZoom.Value &&
+                PiPDisablerPlugin.EnableZoom &&
                 ScopeLifecycle.IsScoped &&
                 !ScopeLifecycle.IsModBypassedForCurrentScope &&
                 !FreelookTracker.IsFreelooking &&

--- a/Patches/PiPDisabler.cs
+++ b/Patches/PiPDisabler.cs
@@ -61,7 +61,7 @@ namespace PiPDisabler
 
 internal static void TickBaseOpticCamera()
         {
-            if (!PiPDisablerPlugin.DisablePiP.Value) return;
+            if (!PiPDisablerPlugin.DisablePiP) return;
 
             // Any condition that should preserve vanilla PiP must restore and skip disabling.
             if (ShouldAllowVanillaPiP())
@@ -205,7 +205,7 @@ internal static bool ShouldIgnoreOnDisable(OpticSight os)
                 if (ScopeLifecycle.IsNameBypassed(os))
                     return true;
 
-                if (!PiPDisablerPlugin.AutoDisableForVariableScopes.Value)
+                if (!PiPDisablerPlugin.AutoDisableForVariableScopes)
                     return false;
 
                 if (FovController.IsOpticAdjustable(os))
@@ -319,7 +319,7 @@ _ignoreOnDisableFrame.Clear();
         private static bool ShouldAllowVanillaPiP()
         {
             return !PiPDisablerPlugin.ModEnabled.Value
-                || !PiPDisablerPlugin.DisablePiP.Value
+                || !PiPDisablerPlugin.DisablePiP
                 || ScopeLifecycle.IsModBypassedForCurrentScope
                 || ScopeLifecycle.IsLastOpticNameBypassed();
         }
@@ -333,7 +333,7 @@ _ignoreOnDisableFrame.Clear();
             private static void Postfix(OpticComponentUpdater __instance)
             {
                 if (!PiPDisablerPlugin.ModEnabled.Value) return;
-                if (!PiPDisablerPlugin.DisablePiP.Value) return;
+                if (!PiPDisablerPlugin.DisablePiP) return;
                 if (__instance == null) return;
                 if (ShouldSuppressPiPDisableForCurrentOptic(__instance)) return;
 
@@ -359,7 +359,7 @@ _ignoreOnDisableFrame.Clear();
                 if (!PiPDisablerPlugin.ModEnabled.Value) return true;
                 if (__instance == null) return true;
 
-                if (PiPDisablerPlugin.DisablePiP.Value)
+                if (PiPDisablerPlugin.DisablePiP)
                 {
                     OpticCameraTransform = __instance.transform;
                     Debug_LastOpticCameraTransform = OpticCameraTransform;

--- a/Patches/ScopeDiagnostics.cs
+++ b/Patches/ScopeDiagnostics.cs
@@ -107,7 +107,7 @@ namespace PiPDisabler
                 }
                 else
                 {
-                    sb.AppendLine($"[Diagnostics] Magnification   : no ScopeZoomHandler — using DefaultZoom ({PiPDisablerPlugin.DefaultZoom.Value:F1}x)");
+                    sb.AppendLine($"[Diagnostics] Magnification   : no ScopeZoomHandler — using DefaultZoom ({PiPDisablerPlugin.DefaultZoom:F1}x)");
                 }
             }
             catch (System.Exception ex)

--- a/Patches/ScopeLifecycle.cs
+++ b/Patches/ScopeLifecycle.cs
@@ -225,7 +225,7 @@ namespace PiPDisabler
                 FovController.OnModeSwitch();
 
                 // RESTORE all meshes first, then re-cut with new mode's plane position.
-                if (PiPDisablerPlugin.EnableMeshSurgery.Value)
+                if (PiPDisablerPlugin.EnableMeshSurgery)
                 {
                     MeshSurgeryManager.RestoreForScope(os.transform);
                     MeshSurgeryManager.ApplyForOptic(os);
@@ -575,7 +575,7 @@ namespace PiPDisabler
             if (ShouldBypassByWhitelist(os))
                 return true;
 
-            if (PiPDisablerPlugin.AutoDisableForVariableScopes.Value
+            if (PiPDisablerPlugin.AutoDisableForVariableScopes
                 && (FovController.IsOpticAdjustable(os) || IsThermalOrNightVisionOptic(os)))
                 return true;
 
@@ -588,7 +588,7 @@ namespace PiPDisabler
         private static bool ScopeNameMatchesBypassPattern(OpticSight os)
         {
             if (os == null) return false;
-            string raw = PiPDisablerPlugin.AutoBypassNameContains?.Value;
+            string raw = PiPDisablerPlugin.AutoBypassNameContains;
             if (string.IsNullOrWhiteSpace(raw)) return false;
 
             string scopeKey   = ResolveWhitelistScopeKey(os) ?? string.Empty;
@@ -838,12 +838,12 @@ namespace PiPDisabler
             ScopeEffectsRenderer.Show();
 
             // 5. Mesh surgery (once)
-            if (PiPDisablerPlugin.EnableMeshSurgery.Value)
+            if (PiPDisablerPlugin.EnableMeshSurgery)
                 MeshSurgeryManager.ApplyForOptic(os);
 
             // 6. Show cut plane visualizer (even without mesh surgery, for debugging)
             if (PiPDisablerPlugin.GetShowCutPlane()
-                && !PiPDisablerPlugin.EnableMeshSurgery.Value)
+                && !PiPDisablerPlugin.EnableMeshSurgery)
             {
                 ShowPlaneOnly(os);
             }
@@ -942,8 +942,7 @@ namespace PiPDisabler
         private static List<Renderer> CollectStencilRenderers(OpticSight os)
         {
             var housing = LensTransparency.CollectHousingRenderers(os);
-            if (PiPDisablerPlugin.StencilIncludeWeaponMeshes != null
-                && PiPDisablerPlugin.StencilIncludeWeaponMeshes.Value)
+            if (PiPDisablerPlugin.StencilIncludeWeaponMeshes)
             {
                 housing.AddRange(LensTransparency.CollectWeaponRenderers(os, housing));
             }
@@ -959,7 +958,7 @@ namespace PiPDisabler
             try
             {
                 if (_modBypassedForCurrentScope) return;
-                if (!PiPDisablerPlugin.EnableZoom.Value) return;
+                if (!PiPDisablerPlugin.EnableZoom) return;
                 if (!CameraClass.Exist) return;
 
                 float zoomBaseFov = FovController.ZoomBaselineFov;

--- a/Patches/WeaponScalingPatch.cs
+++ b/Patches/WeaponScalingPatch.cs
@@ -58,7 +58,7 @@ namespace PiPDisabler.Patches
         /// </summary>
         public static void CaptureBaseState()
         {
-            if (!PiPDisablerPlugin.EnableWeaponScaling.Value) return;
+            if (!PiPDisablerPlugin.EnableWeaponScaling) return;
             var os = ScopeLifecycle.ActiveOptic;
             if (os == null) { _isActive = false; return; }
             _isActive = true;
@@ -72,7 +72,7 @@ namespace PiPDisabler.Patches
         public static void UpdateScale()
         {
             if (!_isActive) return;
-            if (!PiPDisablerPlugin.EnableWeaponScaling.Value) return;
+            if (!PiPDisablerPlugin.EnableWeaponScaling) return;
 
             try
             {
@@ -132,8 +132,8 @@ namespace PiPDisabler.Patches
         {
             float halfRefRad = ZoomBaseline * 0.5f * Mathf.Deg2Rad;
             float halfCurRad = currentFov * 0.5f * Mathf.Deg2Rad;
-            float baseline = PiPDisablerPlugin.BaselineWeaponScale.Value;
-            float strength = PiPDisablerPlugin.WeaponScaleStrength.Value;
+            float baseline = PiPDisablerPlugin.BaselineWeaponScale;
+            float strength = PiPDisablerPlugin.WeaponScaleStrength;
             float tanRef = Mathf.Tan(halfRefRad);
             float tanCur = Mathf.Tan(halfCurRad);
             float invRatio = tanRef / tanCur;
@@ -157,7 +157,7 @@ namespace PiPDisabler.Patches
             try
             {
                 if (!__instance.IsYourPlayer) return;
-                if (!PiPDisablerPlugin.EnableWeaponScaling.Value) return;
+                if (!PiPDisablerPlugin.EnableWeaponScaling) return;
                 if (!ScopeLifecycle.IsScoped) return;
                 if (ScopeLifecycle.IsModBypassedForCurrentScope) return;
                 if (!_isActive) return;

--- a/Patches/ZeroingController.cs
+++ b/Patches/ZeroingController.cs
@@ -55,15 +55,15 @@ namespace PiPDisabler
         /// </summary>
         public static void Tick()
         {
-            if (!PiPDisablerPlugin.EnableZeroing.Value) return;
+            if (!PiPDisablerPlugin.EnableZeroing) return;
             if (!ScopeLifecycle.IsScoped) return;
 
             // Cooldown
             if (Time.unscaledTime - _lastZeroingTime < ZEROING_COOLDOWN) return;
 
             // Poll input
-            KeyCode upKey   = PiPDisablerPlugin.ZeroingUpKey.Value;
-            KeyCode downKey = PiPDisablerPlugin.ZeroingDownKey.Value;
+            KeyCode upKey   = PiPDisablerPlugin.ZeroingUpKey;
+            KeyCode downKey = PiPDisablerPlugin.ZeroingDownKey;
 
             bool wantsUp   = UnityEngine.Input.GetKeyDown(upKey);
             bool wantsDown = UnityEngine.Input.GetKeyDown(downKey);

--- a/Patches/ZoomController.cs
+++ b/Patches/ZoomController.cs
@@ -21,7 +21,7 @@ namespace PiPDisabler
         /// </summary>
         public static float GetMagnification(OpticSight os)
         {
-            if (os == null) return PiPDisablerPlugin.DefaultZoom.Value;
+            if (os == null) return PiPDisablerPlugin.DefaultZoom;
 
             // Ensure range is discovered
             if (!_rangeDiscovered)
@@ -39,7 +39,7 @@ namespace PiPDisabler
         /// </summary>
         public static float GetMinFov(OpticSight os)
         {
-            if (os == null) return 35f / PiPDisablerPlugin.DefaultZoom.Value;
+            if (os == null) return 35f / PiPDisablerPlugin.DefaultZoom;
 
             // Try template zoom range first
             var (minZoom, maxZoom) = FovController.GetTemplateZoomRange();

--- a/PiPDisablerPlugin.cs
+++ b/PiPDisablerPlugin.cs
@@ -116,49 +116,46 @@ namespace PiPDisabler
         // --- 0. Global ---
         internal static ConfigEntry<bool> ModEnabled;
         internal static ConfigEntry<KeyCode> ModToggleKey;
-        internal static ConfigEntry<bool> AutoSwitchReticleRenderForNvg;
+        internal const bool AutoSwitchReticleRenderForNvg = true;
 
         // --- General ---
-        internal static ConfigEntry<bool> DisablePiP;
-        internal static ConfigEntry<bool> AutoDisableForVariableScopes;
-        internal static ConfigEntry<string> AutoBypassNameContains;
+        internal const bool DisablePiP = true;
+        internal const bool AutoDisableForVariableScopes = true;
+        internal const string AutoBypassNameContains = "npz, PU, vomz, d-evo";
         internal static ConfigEntry<string> ScopeWhitelistNames;
         internal static ConfigEntry<KeyCode> ScopeWhitelistToggleEntryKey;
-        internal static ConfigEntry<KeyCode> DisablePiPToggleKey;
-        internal static ConfigEntry<bool> MakeLensesTransparent;
-        internal static ConfigEntry<KeyCode> LensesTransparentToggleKey;
-        internal static ConfigEntry<bool> BlackLensWhenUnscoped;
+        internal const bool MakeLensesTransparent = true;
+        internal const bool BlackLensWhenUnscoped = true;
 
         // --- Mesh Surgery ---
-        internal static ConfigEntry<bool> EnableMeshSurgery;
-        internal static ConfigEntry<KeyCode> MeshSurgeryToggleKey;
-        internal static ConfigEntry<bool> RestoreOnUnscope;
-        internal static ConfigEntry<float> PlaneOffsetMeters;
-        internal static ConfigEntry<string> PlaneNormalAxis;
-        internal static ConfigEntry<float> CutRadius;
-        internal static ConfigEntry<bool> ShowCutPlane;
-        internal static ConfigEntry<bool> ShowCutVolume;
-        internal static ConfigEntry<float> CutVolumeOpacity;
-        internal static ConfigEntry<string> CutMode;
-        internal static ConfigEntry<float> CylinderRadius;
-        internal static ConfigEntry<float> MidCylinderRadius;
-        internal static ConfigEntry<float> MidCylinderPosition;
-        internal static ConfigEntry<float> FarCylinderRadius;
-        internal static ConfigEntry<float> Plane1OffsetMeters;
-        internal static ConfigEntry<float> Plane2Position;
-        internal static ConfigEntry<float> Plane2Radius;
-        internal static ConfigEntry<float> Plane3Position;
-        internal static ConfigEntry<float> Plane3Radius;
-        internal static ConfigEntry<float> Plane4Position;
-        internal static ConfigEntry<float> Plane4Radius;
-        internal static ConfigEntry<float> CutStartOffset;
-        internal static ConfigEntry<float> CutLength;
-        internal static ConfigEntry<float> NearPreserveDepth;
-        internal static ConfigEntry<bool> ShowReticle;
-        internal static ConfigEntry<float> ReticleBaseSize;
-        internal static ConfigEntry<bool> ExpandSearchToWeaponRoot;
-        internal static ConfigEntry<bool> DebugShowHousingMask;
-        internal static ConfigEntry<bool> StencilIncludeWeaponMeshes;
+        internal const bool EnableMeshSurgery = true;
+        internal const bool RestoreOnUnscope = true;
+        private const float PlaneOffsetMeters = 0.001f;
+        private const string PlaneNormalAxis = "-Y";
+        private const float CutRadius = 0f;
+        private const bool ShowCutPlane = false;
+        private const bool ShowCutVolume = false;
+        private const float CutVolumeOpacity = 0.49f;
+        private const string CutMode = "Cylinder";
+        private const float CylinderRadius = 0.011f;
+        private const float MidCylinderRadius = 0.013f;
+        private const float MidCylinderPosition = 0.28f;
+        private const float FarCylinderRadius = 0.12f;
+        private const float Plane1OffsetMeters = 0f;
+        private const float Plane2Position = 0.1138498f;
+        private const float Plane2Radius = 0.0186338f;
+        private const float Plane3Position = 0.55f;
+        private const float Plane3Radius = 0.2f;
+        private const float Plane4Position = 1f;
+        private const float Plane4Radius = 0.2f;
+        private const float CutStartOffset = 0.04084507f;
+        private const float CutLength = 0.755493f;
+        private const float NearPreserveDepth = 0.02549295f;
+        private const bool ShowReticle = true;
+        private const float ReticleBaseSize = 0.03f;
+        internal const bool ExpandSearchToWeaponRoot = true;
+        internal const bool DebugShowHousingMask = false;
+        internal const bool StencilIncludeWeaponMeshes = true;
 
         // --- Custom Mesh Surgery settings (per-scope authoring) ---
         internal static ConfigEntry<KeyCode> SaveCustomMeshSurgerySettingsKey;
@@ -203,30 +200,28 @@ namespace PiPDisabler
         internal static ConfigEntry<KeyCode> DiagnosticsKey;
 
         // --- Weapon Scaling ---
-        internal static ConfigEntry<bool> EnableWeaponScaling;
-        internal static ConfigEntry<float> BaselineWeaponScale;
-        internal static ConfigEntry<float> WeaponScaleStrength;
+        internal const bool EnableWeaponScaling = true;
+        internal const float BaselineWeaponScale = 0.9624413f;
+        internal const float WeaponScaleStrength = 0.2723005f;
         // --- Zoom / FOV ---
-        internal static ConfigEntry<bool> EnableZoom;
-        internal static ConfigEntry<float> DefaultZoom;
-        internal static ConfigEntry<bool> AutoFovFromScope;
-        internal static ConfigEntry<float> ScopedFov;
+        internal const bool EnableZoom = true;
+        internal const float DefaultZoom = 4f;
+        internal const bool AutoFovFromScope = true;
+        internal const float ScopedFov = 15f;
         internal static ConfigEntry<float> FovAnimationDuration;
-        internal static ConfigEntry<KeyCode> ZoomToggleKey;
-        internal static ConfigEntry<float> ManualLodBias;
-        internal static ConfigEntry<int> ManualMaximumLodLevel;
-        internal static ConfigEntry<float> ManualCullingMultiplier;
-        internal static Dictionary<string, ConfigEntry<float>> MapManualLodBias;
+        internal const float ManualLodBias = 4.0f;
+        internal const int ManualMaximumLodLevel = -1;
+        internal const float ManualCullingMultiplier = 0.8f;
 
         // --- 4. Zeroing ---
-        internal static ConfigEntry<bool> EnableZeroing;
-        internal static ConfigEntry<KeyCode> ZeroingUpKey;
-        internal static ConfigEntry<KeyCode> ZeroingDownKey;
+        internal const bool EnableZeroing = true;
+        internal const KeyCode ZeroingUpKey = KeyCode.PageUp;
+        internal const KeyCode ZeroingDownKey = KeyCode.PageDown;
 
         // --- Debug ---
         internal static ConfigEntry<bool> VerboseLogging;
-        internal static ConfigEntry<bool> DebugLogCutCandidates;
-        internal static ConfigEntry<bool> DebugReticleAfterEverything;
+        internal const bool DebugLogCutCandidates = false;
+        internal const bool DebugReticleAfterEverything = false;
 
 
         private void Awake()
@@ -234,342 +229,108 @@ namespace PiPDisabler
             Instance = this;
 
             // --- 0. Global ---
-            ModEnabled = Config.Bind("0. Global", "ModEnabled", true,
+            ModEnabled = Config.Bind("1. General", "ModEnabled", true,
                 "Master ON/OFF switch for the entire mod. When OFF, all effects are " +
                 "cleaned up and the game behaves as if the mod is not installed.");
-            ModToggleKey = Config.Bind("0. Global", "ModToggleKey", KeyCode.Backspace,
+            ModToggleKey = Config.Bind("1. General", "ModToggleKey", KeyCode.Backspace,
                 "Toggle key for master mod enable/disable.");
-            AutoSwitchReticleRenderForNvg = Config.Bind("0. Global", "AutoSwitchReticleRenderForNvg", true,
-                "Automatically switch reticle CommandBuffer event based on NVG state.\n" +
-                "ON: use AfterForwardAlpha while NVG are active and AfterEverything otherwise.\n" +
-                "OFF: keep the normal path (AfterForwardAlpha) unless debug override is enabled.");
 
             // --- General ---
-            DisablePiP = Config.Bind("1. General", "DisablePiP", true,
-                "Disable Picture-in-Picture optic rendering (No-PiP mode). " +
-                "Core feature — gives identical perf between hip-fire and ADS.");
-            AutoDisableForVariableScopes = Config.Bind("1. General", "AutoDisableForVariableScopes", true,
-                "Automatically disable all mod effects while scoped with variable magnification optics (IsAdjustableOptic=true).\n" +
-                "Also bypasses thermal/night-vision scopes detected via ScopeData.ThermalVisionData or NightVisionData.");
-            AutoBypassNameContains = Config.Bind("1. General", "AutoBypassNameContains", "npz, PU, vomz, d-evo",
-                "Comma-separated list of substrings. Any scope whose object name or scope key contains one of these ");
-            ScopeWhitelistNames = Config.Bind("1. General", "ScopeWhitelistNames", "",
+            ScopeWhitelistNames = Config.Bind("2. Whitelist", "ScopeWhitelistNames", "",
                 "Comma/semicolon/newline separated list of allowed scope keys.\n" +
                 "Primary key is derived from the object under mod_scope that does not contain mount (case-insensitive).\n" +
                 "Fallbacks: template _name, template _id, then optic object name. Empty list = whitelist ignored.");
-            ScopeWhitelistToggleEntryKey = Config.Bind("1. General", "ScopeWhitelistToggleEntryKey", KeyCode.None,
+            ScopeWhitelistToggleEntryKey = Config.Bind("2. Whitelist", "ScopeWhitelistToggleEntryKey", KeyCode.None,
                 "When pressed while scoped, add/remove the current scope key in ScopeWhitelistNames (derived from mod_scope non-mount object).");
-            DisablePiPToggleKey = Config.Bind("1. General", "DisablePiPToggleKey", KeyCode.None,
-                "Toggle key for PiP disable.");
-
-            MakeLensesTransparent = Config.Bind("1. General", "MakeLensesTransparent", true,
-                "Hide lens surfaces (linza/backLens) while scoped so you see through the tube.");
-            LensesTransparentToggleKey = Config.Bind("1. General", "LensesTransparentToggleKey", KeyCode.None,
-                "Toggle key for lens transparency.");
-            BlackLensWhenUnscoped = Config.Bind("1. General", "BlackLensWhenUnscoped", true,
-                "When unscoping, apply a solid black opaque material to the lens instead of restoring " +
-                "the original PiP/sight material. Eliminates the reticle flash during the unscope " +
-                "transition and gives the scope a realistic dark-glass appearance when not in use.");
 
             // --- Weapon Scaling ---
-            EnableWeaponScaling = Config.Bind("2. Zoom", "EnableWeaponScaling", true,
-                "Compensate weapon/arms model scale across magnification levels.\n" +
-                "Without this, zooming in (lower FOV) makes the weapon appear larger on screen.\n" +
-                "With this enabled, the weapon shrinks proportionally as you zoom in so it\n" +
-                "always occupies the same screen space at every magnification level.");
-            BaselineWeaponScale = Config.Bind("2. Zoom", "BaselineWeaponScale", 0.9624413f,
-                new ConfigDescription(
-                    "Base weapon scale applied at all FOV values before compensation.\n" +
-                    "1.00 = default EFT visual scale.",
-                    new AcceptableValueRange<float>(0.00f, 2.00f)));
-            WeaponScaleStrength = Config.Bind("2. Zoom", "WeaponScaleStrength", 0.2723005f,
-                new ConfigDescription(
-                    "Blends between no compensation and full inverse-FOV compensation.\n" +
-                    "0.00 = no compensation, 1.00 = full compensation, values outside [0,1] over/under-compensate.",
-                    new AcceptableValueRange<float>(-2.00f, 2.00f)));
 
             // --- Zoom ---
-            EnableZoom = Config.Bind("2. Zoom", "EnableZoom", true,
-                "Enable scope magnification via FOV zoom.");
-            DefaultZoom = Config.Bind("2. Zoom", "DefaultZoom", 4f,
-                new ConfigDescription(
-                    "Default magnification when auto-detection fails (e.g. fixed scopes without zoom data).",
-                    new AcceptableValueRange<float>(1f, 16f)));
-            AutoFovFromScope = Config.Bind("2. Zoom", "AutoFovFromScope", true,
-                "Auto-detect magnification from the scope's zoom data (ScopeZoomHandler). " +
-                "Works for variable-zoom scopes. Falls back to DefaultZoom for fixed scopes.");
-            ScopedFov = Config.Bind("2. Zoom", "ScopedFov", 15f,
-                new ConfigDescription(
-                    "FOV (degrees) for FOV zoom fallback mode. Lower = more zoom. " +
-                    "Used for FOV zoom.",
-                    new AcceptableValueRange<float>(5f, 75f)));
-            FovAnimationDuration = Config.Bind("2. Zoom", "FovAnimationDuration", 1f,
+            FovAnimationDuration = Config.Bind("1. General", "FovAnimationDuration", 1f,
                 new ConfigDescription(
                     "Duration (seconds) of the FOV zoom-in animation when entering ADS.\n" +
                     "0 = instant snap. 0.25 = smooth quarter-second transition.\n" +
                     "Scope exit always restores FOV instantly to avoid sluggish feel.",
                     new AcceptableValueRange<float>(0f, 2f)));
 
-            ManualLodBias = Config.Bind("2. Zoom", "ManualLodBias", 4.0f,
-                new ConfigDescription(
-                    "Manual LOD bias while scoped.\n" +
-                    "0 = auto (baseLodBias * magnification).\n" +
-                    ">0 = force this exact value (e.g. 4.0).",
-                    new AcceptableValueRange<float>(0f, 20f)));
-            ManualMaximumLodLevel = Config.Bind("2. Zoom", "ManualMaximumLodLevel", -1,
-                new ConfigDescription(
-                    "Manual QualitySettings.maximumLODLevel while scoped.\n" +
-                    "-1 = auto (force 0 / highest detail).\n" +
-                    ">=0 = force this exact max LOD level.",
-                    new AcceptableValueRange<int>(-1, 8)));
-            ManualCullingMultiplier = Config.Bind("2. Zoom", "ManualCullingMultiplier", 0.8f,
-                new ConfigDescription(
-                    "Manual multiplier for Camera.layerCullDistances while scoped.\n" +
-                    "0 = auto (use magnification).\n" +
-                    ">0 = force this multiplier (e.g. 2.0 doubles cull distances).",
-                    new AcceptableValueRange<float>(0f, 20f)));
-            MapManualLodBias = new Dictionary<string, ConfigEntry<float>>(StringComparer.OrdinalIgnoreCase);
-
-            BindPerMapLodBias("Woods", "Woods", "Woods");
-            BindPerMapLodBias("Factory", "Factory", "factory4_day", "factory4_night");
-            BindPerMapLodBias("Customs", "Customs", "bigmap");
-            BindPerMapLodBias("Shoreline", "Shoreline", "Shoreline");
-            BindPerMapLodBias("Interchange", "Interchange", "Interchange");
-            BindPerMapLodBias("Reserve", "Reserve", "RezervBase");
-            BindPerMapLodBias("TheLab", "The Lab", "laboratory");
-            BindPerMapLodBias("Lighthouse", "Lighthouse", "Lighthouse");
-            BindPerMapLodBias("StreetsOfTarkov", "Streets of Tarkov", "TarkovStreets");
-            BindPerMapLodBias("GroundZero", "Ground Zero", "Sandbox", "Sandbox_high");
-            ZoomToggleKey = Config.Bind("2. Zoom", "ZoomToggleKey", KeyCode.None,
-                "Toggle key for zoom (None = always on when EnableZoom is true).");
-
             // --- 4. Zeroing ---
-            EnableZeroing = Config.Bind("4. Zeroing", "EnableZeroing", true,
-                "Enable optic zeroing (calibration distance adjustment) via keyboard.\n" +
-                "Uses the proper EFT pathway (works with Fika).");
-            ZeroingUpKey = Config.Bind("4. Zeroing", "ZeroingUpKey", KeyCode.PageUp,
-                "Key to increase zeroing distance.");
-            ZeroingDownKey = Config.Bind("4. Zeroing", "ZeroingDownKey", KeyCode.PageDown,
-                "Key to decrease zeroing distance.");
 
             // --- Mesh Surgery (ON by default, Cylinder mode) ---
-            EnableMeshSurgery = Config.Bind("3. Global Mesh Surgery settings", "EnableMeshSurgery", true,
-                "Enable runtime mesh cutting to bore a hole through the scope housing.");
-            MeshSurgeryToggleKey = Config.Bind("3. Global Mesh Surgery settings", "MeshSurgeryToggleKey", KeyCode.None,
-                "Toggle key for mesh surgery.");
-            RestoreOnUnscope = Config.Bind("3. Global Mesh Surgery settings", "RestoreOnUnscope", true,
-                "Restore original meshes when leaving scope.");
-            PlaneOffsetMeters = Config.Bind("3. Global Mesh Surgery settings", "PlaneOffsetMeters", 0.001f,
-                "Offset applied along plane normal (meters).");
-            PlaneNormalAxis = Config.Bind("3. Global Mesh Surgery settings", "PlaneNormalAxis", "-Y",
-                new ConfigDescription(
-                    "Which local axis to use as the cut plane normal.\n" +
-                    "Auto = use backLens.forward (game default).\n" +
-                    "X/Y/Z = force that local axis as the plane normal.\n" +
-                    "-X/-Y/-Z = force the negative of that axis.\n" +
-                    "If the cut is horizontal when it should be vertical, try Z or Y.",
-                    new AcceptableValueList<string>("Auto", "X", "Y", "Z", "-X", "-Y", "-Z")));
-            CutRadius = Config.Bind("3. Global Mesh Surgery settings", "CutRadius", 0f,
-                new ConfigDescription(
-                    "Max distance (meters) from scope center to cut. 0 = unlimited (cut all geometry).\n" +
-                    "Set to e.g. 0.05 to only cut geometry near the lens opening.",
-                    new AcceptableValueRange<float>(0f, 1f)));
-            ShowCutPlane = Config.Bind("3. Global Mesh Surgery settings", "ShowCutPlane", false,
-                "Show green/red semi-transparent circles at the near/far cut plane positions.\n" +
-                "Use this to visualize the cut endpoints.");
-            ShowCutVolume = Config.Bind("3. Global Mesh Surgery settings", "ShowCutVolume", false,
-                "Show a semi-transparent 3D tube representing the full cut volume.\n" +
-                "Visualizes the near→mid→far radius profile so you can see exactly what gets removed.");
-            CutVolumeOpacity = Config.Bind("3. Global Mesh Surgery settings", "CutVolumeOpacity", 0.49f,
-                new ConfigDescription(
-                    "Opacity of the 3D cut volume visualizer (0 = invisible, 1 = opaque).",
-                    new AcceptableValueRange<float>(0.05f, 0.8f)));
-            CutMode = Config.Bind("3. Global Mesh Surgery settings", "CutMode", "Cylinder",
-                new ConfigDescription(
-                    "Plane = flat infinite cut. Cylinder = cylindrical bore cut centered on the lens axis.\n" +
-                    "Cylinder removes geometry inside a cylinder of CylinderRadius around the lens center.",
-                    new AcceptableValueList<string>("Plane", "Cylinder")));
-            CylinderRadius = Config.Bind("3. Global Mesh Surgery settings", "CylinderRadius", 0.011f,
-                new ConfigDescription(
-                    "Near radius (meters) of the cylindrical/cone cut (camera side).\n" +
-                    "Typical scope lens radius is ~0.01-0.02m.",
-                    new AcceptableValueRange<float>(0.001f, 0.1f)));
-            MidCylinderRadius = Config.Bind("3. Global Mesh Surgery settings", "MidCylinderRadius", 0.013f,
-                new ConfigDescription(
-                    "Intermediate radius (meters) at MidCylinderPosition along the bore.\n" +
-                    "0 = disabled (linear near→far interpolation).\n" +
-                    ">0 = two-segment interpolation: near→mid, then mid→far.\n" +
-                    "Set smaller than near/far to create a waist (hourglass). Set larger for a bulge.",
-                    new AcceptableValueRange<float>(0f, 0.2f)));
-            MidCylinderPosition = Config.Bind("3. Global Mesh Surgery settings", "MidCylinderPosition", 0.28f,
-                new ConfigDescription(
-                    "Position of the mid-radius control point along the cut length (0=near, 1=far).\n" +
-                    "0.5 = midpoint. 0.3 = closer to camera. 0.7 = closer to objective.",
-                    new AcceptableValueRange<float>(0.01f, 0.99f)));
-            FarCylinderRadius = Config.Bind("3. Global Mesh Surgery settings", "FarCylinderRadius", 0.12f,
-                new ConfigDescription(
-                    "Far radius (meters) of the cone cut (objective side).\n" +
-                    "0 = same as CylinderRadius (pure cylinder). >0 creates a cone/frustum shape.\n" +
-                    "Set larger than CylinderRadius to widen the bore toward the objective lens.",
-                    new AcceptableValueRange<float>(0f, 0.2f)));
-            Plane1OffsetMeters = Config.Bind("3. Global Mesh Surgery settings", "Plane1OffsetMeters", 0f,
-                new ConfigDescription(
-                    "Offset (meters) for plane 1 from linza/backLens origin along bore axis.\n" +
-                    "Plane 1 radius is always CylinderRadius.",
-                    new AcceptableValueRange<float>(-0.02f, 0.02f)));
-            Plane2Position = Config.Bind("3. Global Mesh Surgery settings", "Plane2Position", 0.1138498f,
-                new ConfigDescription(
-                    "Plane 2 profile position (0..1) anchored from the near side.\n" +
-                    "Changing CutLength keeps this plane at the same world-space depth from near.",
-                    new AcceptableValueRange<float>(0f, 1f)));
-            Plane2Radius = Config.Bind("3. Global Mesh Surgery settings", "Plane2Radius", 0.0186338f,
-                new ConfigDescription(
-                    "Radius (meters) at plane 2.",
-                    new AcceptableValueRange<float>(0f, 0.2f)));
-            Plane3Position = Config.Bind("3. Global Mesh Surgery settings", "Plane3Position", 0.55f,
-                new ConfigDescription(
-                    "Normalized depth of plane 3 from near (0) to far (1).",
-                    new AcceptableValueRange<float>(0f, 1f)));
-            Plane3Radius = Config.Bind("3. Global Mesh Surgery settings", "Plane3Radius", 0.2f,
-                new ConfigDescription(
-                    "Radius (meters) at plane 3.",
-                    new AcceptableValueRange<float>(0f, 0.2f)));
-            Plane4Position = Config.Bind("3. Global Mesh Surgery settings", "Plane4Position", 1f,
-                new ConfigDescription(
-                    "Normalized depth of plane 4 from near (0) to far (1). Usually 1.",
-                    new AcceptableValueRange<float>(0f, 1f)));
-            Plane4Radius = Config.Bind("3. Global Mesh Surgery settings", "Plane4Radius", 0.2f,
-                new ConfigDescription(
-                    "Radius (meters) at plane 4 (away from player).",
-                    new AcceptableValueRange<float>(0f, 0.2f)));
-            CutStartOffset = Config.Bind("3. Global Mesh Surgery settings", "CutStartOffset", 0.04084507f,
-                new ConfigDescription(
-                    "How far behind the backLens (toward the camera) the near cut plane starts.\n" +
-                    "The near plane is fixed at: backLens - (offset × boreAxis).\n" +
-                    "0 = starts exactly at the backLens. 0.05 = 5cm behind it (catches interior tube geometry).\n" +
-                    "Changing CutLength does NOT move this plane.",
-                    new AcceptableValueRange<float>(0f, 0.3f)));
-            CutLength = Config.Bind("3. Global Mesh Surgery settings", "CutLength", 0.755493f,
-                new ConfigDescription(
-                    "How far forward from the near plane the cut extends (toward the objective).\n" +
-                    "The far plane is at: nearPlane + (length × boreAxis).\n" +
-                    "Only the far plane moves when you change this value.",
-                    new AcceptableValueRange<float>(0.01f, 1f)));
-            NearPreserveDepth = Config.Bind("3. Global Mesh Surgery settings", "NearPreserveDepth", 0.02549295f,
-                new ConfigDescription(
-                    "Depth (meters) from the near cut plane where NO geometry is cut.\n" +
-                    "Preserves the eyepiece housing closest to the camera so you\n" +
-                    "keep a thin ring framing the reticle while ADSing.\n" +
-                    "0.01 = 1cm ring (default). 0.02-0.04 = thicker ring.\n" +
-                    "0 = disabled (cut starts at the near plane — removes everything).",
-                    new AcceptableValueRange<float>(0f, 0.15f)));
-            ShowReticle = Config.Bind("3. Global Mesh Surgery settings", "ShowReticle", true,
-                "Render the scope reticle texture as a glowing overlay where the lens was.\n" +
-                "Uses alpha blending so the reticle's own alpha channel controls transparency.");
-            ReticleBaseSize = Config.Bind("3. Global Mesh Surgery settings", "ReticleBaseSize", 0.030f,
-                new ConfigDescription(
-                    "Physical diameter (meters) of the reticle quad at 1x magnification.\n" +
-                    "The quad is scaled by 1/magnification so screen-pixel coverage stays constant\n" +
-                    "across all zoom levels.  Typical scope lens diameter is 0.02-0.04 m.\n" +
-                    "Set to 0 to fall back to the legacy CylinderRadius x2 value.",
-                    new AcceptableValueRange<float>(0f, 0.2f)));
-            ExpandSearchToWeaponRoot = Config.Bind("3. Global Mesh Surgery settings", "ExpandSearchToWeaponRoot", true,
-                "Expand the mesh surgery search root all the way up to the Weapon_root node.\n" +
-                "When enabled, meshes on the weapon body under Weapon_root are also candidates\n" +
-                "for cutting — not just those in the scope sub-hierarchy.\n" +
-                "Use this when scope geometry blends into the weapon receiver and you need to cut\n" +
-                "the underlying weapon meshes as well.\n" +
-                "Example path: Weapon_root/Weapon_root_anim/weapon/mod_scope/...");
-            DebugShowHousingMask = Config.Bind("3. Global Mesh Surgery settings", "DebugShowHousingMask", false,
-                "Render a red/yellow overlay wherever the scope housing stencil mask is\n" +
-                "suppressing the reticle.  Use this to diagnose which meshes are incorrectly\n" +
-                "masking the aperture.  Combine with the BepInEx log to see the exact renderer\n" +
-                "names printed by CollectHousingRenderers.  Disable in normal play.");
-            StencilIncludeWeaponMeshes = Config.Bind("3. Global Mesh Surgery settings", "StencilIncludeWeaponMeshes", true,
-                "Include weapon body renderers (found under the 'weapon' transform) in the\n" +
-                "stencil mask alongside the scope housing.  Prevents the reticle from\n" +
-                "bleeding through the weapon mesh at screen centre.");
 
             // --- Custom Mesh Surgery settings ---
-            SaveCustomMeshSurgerySettingsKey = Config.Bind("4. Custom Mesh Surgery settings", "SaveCustomMeshSurgerySettingsKey", KeyCode.None,
+            SaveCustomMeshSurgerySettingsKey = Config.Bind("5. Custom mesh surgery settings", "SaveCustomMeshSurgerySettingsKey", KeyCode.None,
                 "When pressed while scoped, save all values from this category for the active scope key into custom_mesh_surgery_settings.json.");
-            DeleteCustomMeshSurgerySettingsKey = Config.Bind("4. Custom Mesh Surgery settings", "DeleteCustomMeshSurgerySettingsKey", KeyCode.None,
+            DeleteCustomMeshSurgerySettingsKey = Config.Bind("5. Custom mesh surgery settings", "DeleteCustomMeshSurgerySettingsKey", KeyCode.None,
                 "When pressed while scoped, delete custom mesh surgery settings for the active scope key from custom_mesh_surgery_settings.json.");
-            CustomPlaneOffsetMeters = Config.Bind("4. Custom Mesh Surgery settings", "PlaneOffsetMeters", 0.001f, "Custom per-scope plane offset applied along plane normal (meters).");
-            CustomPlaneNormalAxis = Config.Bind("4. Custom Mesh Surgery settings", "PlaneNormalAxis", "-Y", new ConfigDescription("Custom per-scope local axis for the cut plane normal.", new AcceptableValueList<string>("Auto", "X", "Y", "Z", "-X", "-Y", "-Z")));
-            CustomCutRadius = Config.Bind("4. Custom Mesh Surgery settings", "CutRadius", 0f, new ConfigDescription("Custom per-scope max cut distance in meters (0 = unlimited).", new AcceptableValueRange<float>(0f, 1f)));
-            CustomShowCutPlane = Config.Bind("4. Custom Mesh Surgery settings", "ShowCutPlane", false, "Custom per-scope cut plane visualizer toggle.");
-            CustomShowCutVolume = Config.Bind("4. Custom Mesh Surgery settings", "ShowCutVolume", false, "Custom per-scope cut volume visualizer toggle.");
-            CustomCutVolumeOpacity = Config.Bind("4. Custom Mesh Surgery settings", "CutVolumeOpacity", 0.49f, new ConfigDescription("Custom per-scope cut volume opacity.", new AcceptableValueRange<float>(0.05f, 0.8f)));
-            CustomCutMode = Config.Bind("4. Custom Mesh Surgery settings", "CutMode", "Cylinder", new ConfigDescription("Custom per-scope mesh cut mode.", new AcceptableValueList<string>("Plane", "Cylinder")));
-            CustomCylinderRadius = Config.Bind("4. Custom Mesh Surgery settings", "CylinderRadius", 0.011f, new ConfigDescription("Custom per-scope near radius in meters.", new AcceptableValueRange<float>(0.001f, 0.1f)));
-            CustomMidCylinderRadius = Config.Bind("4. Custom Mesh Surgery settings", "MidCylinderRadius", 0.013f, new ConfigDescription("Custom per-scope mid profile radius in meters.", new AcceptableValueRange<float>(0f, 0.2f)));
-            CustomMidCylinderPosition = Config.Bind("4. Custom Mesh Surgery settings", "MidCylinderPosition", 0.28f, new ConfigDescription("Custom per-scope mid profile position (0..1).", new AcceptableValueRange<float>(0.01f, 0.99f)));
-            CustomFarCylinderRadius = Config.Bind("4. Custom Mesh Surgery settings", "FarCylinderRadius", 0.12f, new ConfigDescription("Custom per-scope far radius in meters.", new AcceptableValueRange<float>(0f, 0.2f)));
-            CustomPlane1OffsetMeters = Config.Bind("4. Custom Mesh Surgery settings", "Plane1OffsetMeters", 0f, new ConfigDescription("Custom per-scope plane 1 offset in meters.", new AcceptableValueRange<float>(-0.02f, 0.02f)));
-            CustomPlane2Position = Config.Bind("4. Custom Mesh Surgery settings", "Plane2Position", 0.1138498f, new ConfigDescription("Custom per-scope plane 2 position (0..1), anchored from near when CutLength changes.", new AcceptableValueRange<float>(0f, 1f)));
-            CustomPlane2Radius = Config.Bind("4. Custom Mesh Surgery settings", "Plane2Radius", 0.0186338f, new ConfigDescription("Custom per-scope plane 2 radius in meters.", new AcceptableValueRange<float>(0f, 0.2f)));
-            CustomPlane3Position = Config.Bind("4. Custom Mesh Surgery settings", "Plane3Position", 0.55f, new ConfigDescription("Custom per-scope plane 3 depth (0..1).", new AcceptableValueRange<float>(0f, 1f)));
-            CustomPlane3Radius = Config.Bind("4. Custom Mesh Surgery settings", "Plane3Radius", 0.2f, new ConfigDescription("Custom per-scope plane 3 radius in meters.", new AcceptableValueRange<float>(0f, 0.2f)));
-            CustomPlane4Position = Config.Bind("4. Custom Mesh Surgery settings", "Plane4Position", 1f, new ConfigDescription("Custom per-scope plane 4 depth (0..1).", new AcceptableValueRange<float>(0f, 1f)));
-            CustomPlane4Radius = Config.Bind("4. Custom Mesh Surgery settings", "Plane4Radius", 0.2f, new ConfigDescription("Custom per-scope plane 4 radius in meters.", new AcceptableValueRange<float>(0f, 0.2f)));
-            CustomCutStartOffset = Config.Bind("4. Custom Mesh Surgery settings", "CutStartOffset", 0.04084507f, new ConfigDescription("Custom per-scope cut start offset in meters.", new AcceptableValueRange<float>(-0.2f, 0.2f)));
-            CustomCutLength = Config.Bind("4. Custom Mesh Surgery settings", "CutLength", 0.755493f, new ConfigDescription("Custom per-scope cut length in meters.", new AcceptableValueRange<float>(0.01f, 4f)));
-            CustomNearPreserveDepth = Config.Bind("4. Custom Mesh Surgery settings", "NearPreserveDepth", 0.02549295f, new ConfigDescription("Custom per-scope near preserve depth in meters.", new AcceptableValueRange<float>(0f, 0.2f)));
-            CustomShowReticle = Config.Bind("4. Custom Mesh Surgery settings", "ShowReticle", true, "Custom per-scope reticle visibility.");
-            CustomReticleBaseSize = Config.Bind("4. Custom Mesh Surgery settings", "ReticleBaseSize", 0.030f, new ConfigDescription("Custom per-scope reticle base diameter in meters.", new AcceptableValueRange<float>(0f, 0.2f)));
-            CustomRestoreOnUnscope = Config.Bind("4. Custom Mesh Surgery settings", "RestoreOnUnscope", true, "Custom per-scope restore behavior when leaving scope.");
-            CustomExpandSearchToWeaponRoot = Config.Bind("4. Custom Mesh Surgery settings", "ExpandSearchToWeaponRoot", true, "Custom per-scope search root expansion to Weapon_root.");
+            CustomPlaneOffsetMeters = Config.Bind("5. Custom mesh surgery settings", "PlaneOffsetMeters", 0.001f, "Custom per-scope plane offset applied along plane normal (meters).");
+            CustomPlaneNormalAxis = Config.Bind("5. Custom mesh surgery settings", "PlaneNormalAxis", "-Y", new ConfigDescription("Custom per-scope local axis for the cut plane normal.", new AcceptableValueList<string>("Auto", "X", "Y", "Z", "-X", "-Y", "-Z")));
+            CustomCutRadius = Config.Bind("5. Custom mesh surgery settings", "CutRadius", 0f, new ConfigDescription("Custom per-scope max cut distance in meters (0 = unlimited).", new AcceptableValueRange<float>(0f, 1f)));
+            CustomShowCutPlane = Config.Bind("5. Custom mesh surgery settings", "ShowCutPlane", false, "Custom per-scope cut plane visualizer toggle.");
+            CustomShowCutVolume = Config.Bind("5. Custom mesh surgery settings", "ShowCutVolume", false, "Custom per-scope cut volume visualizer toggle.");
+            CustomCutVolumeOpacity = Config.Bind("5. Custom mesh surgery settings", "CutVolumeOpacity", 0.49f, new ConfigDescription("Custom per-scope cut volume opacity.", new AcceptableValueRange<float>(0.05f, 0.8f)));
+            CustomCutMode = Config.Bind("5. Custom mesh surgery settings", "CutMode", "Cylinder", new ConfigDescription("Custom per-scope mesh cut mode.", new AcceptableValueList<string>("Plane", "Cylinder")));
+            CustomCylinderRadius = Config.Bind("5. Custom mesh surgery settings", "CylinderRadius", 0.011f, new ConfigDescription("Custom per-scope near radius in meters.", new AcceptableValueRange<float>(0.001f, 0.1f)));
+            CustomMidCylinderRadius = Config.Bind("5. Custom mesh surgery settings", "MidCylinderRadius", 0.013f, new ConfigDescription("Custom per-scope mid profile radius in meters.", new AcceptableValueRange<float>(0f, 0.2f)));
+            CustomMidCylinderPosition = Config.Bind("5. Custom mesh surgery settings", "MidCylinderPosition", 0.28f, new ConfigDescription("Custom per-scope mid profile position (0..1).", new AcceptableValueRange<float>(0.01f, 0.99f)));
+            CustomFarCylinderRadius = Config.Bind("5. Custom mesh surgery settings", "FarCylinderRadius", 0.12f, new ConfigDescription("Custom per-scope far radius in meters.", new AcceptableValueRange<float>(0f, 0.2f)));
+            CustomPlane1OffsetMeters = Config.Bind("5. Custom mesh surgery settings", "Plane1OffsetMeters", 0f, new ConfigDescription("Custom per-scope plane 1 offset in meters.", new AcceptableValueRange<float>(-0.02f, 0.02f)));
+            CustomPlane2Position = Config.Bind("5. Custom mesh surgery settings", "Plane2Position", 0.1138498f, new ConfigDescription("Custom per-scope plane 2 position (0..1), anchored from near when CutLength changes.", new AcceptableValueRange<float>(0f, 1f)));
+            CustomPlane2Radius = Config.Bind("5. Custom mesh surgery settings", "Plane2Radius", 0.0186338f, new ConfigDescription("Custom per-scope plane 2 radius in meters.", new AcceptableValueRange<float>(0f, 0.2f)));
+            CustomPlane3Position = Config.Bind("5. Custom mesh surgery settings", "Plane3Position", 0.55f, new ConfigDescription("Custom per-scope plane 3 depth (0..1).", new AcceptableValueRange<float>(0f, 1f)));
+            CustomPlane3Radius = Config.Bind("5. Custom mesh surgery settings", "Plane3Radius", 0.2f, new ConfigDescription("Custom per-scope plane 3 radius in meters.", new AcceptableValueRange<float>(0f, 0.2f)));
+            CustomPlane4Position = Config.Bind("5. Custom mesh surgery settings", "Plane4Position", 1f, new ConfigDescription("Custom per-scope plane 4 depth (0..1).", new AcceptableValueRange<float>(0f, 1f)));
+            CustomPlane4Radius = Config.Bind("5. Custom mesh surgery settings", "Plane4Radius", 0.2f, new ConfigDescription("Custom per-scope plane 4 radius in meters.", new AcceptableValueRange<float>(0f, 0.2f)));
+            CustomCutStartOffset = Config.Bind("5. Custom mesh surgery settings", "CutStartOffset", 0.04084507f, new ConfigDescription("Custom per-scope cut start offset in meters.", new AcceptableValueRange<float>(-0.2f, 0.2f)));
+            CustomCutLength = Config.Bind("5. Custom mesh surgery settings", "CutLength", 0.755493f, new ConfigDescription("Custom per-scope cut length in meters.", new AcceptableValueRange<float>(0.01f, 4f)));
+            CustomNearPreserveDepth = Config.Bind("5. Custom mesh surgery settings", "NearPreserveDepth", 0.02549295f, new ConfigDescription("Custom per-scope near preserve depth in meters.", new AcceptableValueRange<float>(0f, 0.2f)));
+            CustomShowReticle = Config.Bind("5. Custom mesh surgery settings", "ShowReticle", true, "Custom per-scope reticle visibility.");
+            CustomReticleBaseSize = Config.Bind("5. Custom mesh surgery settings", "ReticleBaseSize", 0.030f, new ConfigDescription("Custom per-scope reticle base diameter in meters.", new AcceptableValueRange<float>(0f, 0.2f)));
+            CustomRestoreOnUnscope = Config.Bind("5. Custom mesh surgery settings", "RestoreOnUnscope", true, "Custom per-scope restore behavior when leaving scope.");
+            CustomExpandSearchToWeaponRoot = Config.Bind("5. Custom mesh surgery settings", "ExpandSearchToWeaponRoot", true, "Custom per-scope search root expansion to Weapon_root.");
 
             // --- Scope Effects ---
-            VignetteEnabled = Config.Bind("5. Scope Effects", "VignetteEnabled", true,
+            VignetteEnabled = Config.Bind("3. Scope effects", "VignetteEnabled", true,
                 "Render a circular vignette ring around the scope aperture.\n" +
                 "A world-space quad at the lens position fading from transparent centre to black edge.");
-            VignetteOpacity = Config.Bind("5. Scope Effects", "VignetteOpacity", 0.39f,
+            VignetteOpacity = Config.Bind("3. Scope effects", "VignetteOpacity", 0.39f,
                 new ConfigDescription("Maximum opacity of the lens vignette ring (0=invisible, 1=full black).",
                     new AcceptableValueRange<float>(0f, 1f)));
-            VignetteSizeMult = Config.Bind("5. Scope Effects", "VignetteSizeMult", 0.35f,
+            VignetteSizeMult = Config.Bind("3. Scope effects", "VignetteSizeMult", 0.35f,
                 new ConfigDescription(
                     "Vignette quad diameter as a multiplier of ReticleBaseSize.\n" +
                     "1.0 = same size as reticle.  1.5 gives a visible border ring.\n" +
                     "Higher values (5-15) may be needed for high-magnification scopes.",
                     new AcceptableValueRange<float>(0f, 1f)));
-            VignetteSoftness = Config.Bind("5. Scope Effects", "VignetteSoftness", 0.51f,
+            VignetteSoftness = Config.Bind("3. Scope effects", "VignetteSoftness", 0.51f,
                 new ConfigDescription(
                     "Fraction of the vignette radius used for the gradient falloff (0=hard edge, 1=full gradient).",
                     new AcceptableValueRange<float>(0f, 1f)));
 
-            ScopeShadowEnabled = Config.Bind("5. Scope Effects", "ScopeShadowEnabled", true,
+            ScopeShadowEnabled = Config.Bind("3. Scope effects", "ScopeShadowEnabled", true,
                 "Overlay a fullscreen scope-tube shadow: black everywhere except a transparent\n" +
                 "circular window in the centre.  Simulates looking down a scope tube.");
-            ScopeShadowOpacity = Config.Bind("5. Scope Effects", "ScopeShadowOpacity", 0.75f,
+            ScopeShadowOpacity = Config.Bind("3. Scope effects", "ScopeShadowOpacity", 0.75f,
                 new ConfigDescription("Maximum opacity of the scope shadow overlay.",
                     new AcceptableValueRange<float>(0f, 1f)));
-            ScopeShadowRadius = Config.Bind("5. Scope Effects", "ScopeShadowRadius", 0.07859156f,
+            ScopeShadowRadius = Config.Bind("3. Scope effects", "ScopeShadowRadius", 0.07859156f,
                 new ConfigDescription(
                     "Radius of the transparent centre window as a fraction of the half-screen (0.0-0.5).\n" +
                     "0.18 = window fills roughly 36% of screen width.  Increase for wider aperture.",
                     new AcceptableValueRange<float>(0.02f, 0.5f)));
-            ScopeShadowSoftness = Config.Bind("5. Scope Effects", "ScopeShadowSoftness", 0.08535211f,
+            ScopeShadowSoftness = Config.Bind("3. Scope effects", "ScopeShadowSoftness", 0.08535211f,
                 new ConfigDescription(
                     "Width of the gradient edge between the clear window and the black shadow (fraction of screen).\n" +
                     "0 = hard edge.  0.05-0.1 is a natural-looking falloff.",
                     new AcceptableValueRange<float>(0f, 0.3f)));
 
             // --- Diagnostics ---
-            DiagnosticsKey = Config.Bind("6. Diagnostics", "DiagnosticsKey", KeyCode.None,
+            DiagnosticsKey = Config.Bind("4. Debug", "DiagnosticsKey", KeyCode.None,
                 "Press to log full diagnostics for the currently active scope: name, hierarchy,\n" +
                 "magnification and cut-plane config.");
 
             // --- Debug ---
-            VerboseLogging = Config.Bind("7. Debug", "VerboseLogging", false,
+            VerboseLogging = Config.Bind("4. Debug", "VerboseLogging", false,
                 "Enable detailed logging. Turn on to diagnose lens/zoom issues.");
-            DebugLogCutCandidates = Config.Bind("7. Debug", "DebugLogCutCandidates", false,
-                "When enabled, logs every mesh candidate found by mesh surgery (path, mesh name, vertices, active state), " +
-                "plus per-candidate radius checks. Useful to diagnose attachments that are not being cut.");
-            DebugReticleAfterEverything = Config.Bind("7. Debug", "DebugReticleAfterEverything", false,
-                "Debug toggle for reticle CommandBuffer event. False = AfterForwardAlpha (default, NVG-friendly). " +
-                "True = AfterEverything (late overlay testing). ");
 
             Patches.Patcher.Enable();
 
@@ -581,32 +342,31 @@ namespace PiPDisabler
 
             // --- Config change handlers (catches config manager changes, not just hotkeys) ---
             ModEnabled.SettingChanged += OnModEnabledChanged;
-            EnableWeaponScaling.SettingChanged += OnWeaponScalingToggled;
             ScopeWhitelistNames.SettingChanged += OnWhitelistSettingsChanged;
 
             LogInfo("PiPDisabler v4.7.0 loaded.");
-            LogInfo($"  ModEnabled={ModEnabled.Value}  DisablePiP={DisablePiP.Value}  MakeLensesTransparent={MakeLensesTransparent.Value}");
+            LogInfo($"  ModEnabled={ModEnabled.Value}  DisablePiP={DisablePiP}  MakeLensesTransparent={MakeLensesTransparent}");
             LogInfo($"  WhitelistNames='{ScopeWhitelistNames.Value}'");
-            LogInfo($"  EnableZoom={EnableZoom.Value}");
-            LogInfo($"  AutoFov={AutoFovFromScope.Value}  DefaultZoom={DefaultZoom.Value}  FovAnimDur={FovAnimationDuration.Value}s");
-            LogInfo($"  EnableMeshSurgery={EnableMeshSurgery.Value}  CutMode={CutMode.Value}  CutLen={CutLength.Value}  NearPreserve={NearPreserveDepth.Value}  ShowReticle={ShowReticle.Value}");
+            LogInfo($"  EnableZoom={EnableZoom}");
+            LogInfo($"  AutoFov={AutoFovFromScope}  DefaultZoom={DefaultZoom}  FovAnimDur={FovAnimationDuration.Value}s");
+            LogInfo($"  EnableMeshSurgery={EnableMeshSurgery}  CutMode={CutMode}  CutLen={CutLength}  NearPreserve={NearPreserveDepth}  ShowReticle={ShowReticle}");
         }
 
         private static ScopeMeshSurgerySettingsEntry ActiveScopeOverride => PerScopeMeshSurgerySettings.GetActiveOverride();
 
-        internal static float GetPlaneOffsetMeters() => ActiveScopeOverride != null ? ActiveScopeOverride.PlaneOffsetMeters : PlaneOffsetMeters.Value;
-        internal static string GetPlaneNormalAxis() => ActiveScopeOverride != null ? ActiveScopeOverride.PlaneNormalAxis : PlaneNormalAxis.Value;
-        internal static float GetCutRadius() => ActiveScopeOverride != null ? ActiveScopeOverride.CutRadius : CutRadius.Value;
-        internal static bool GetShowCutPlane() => ActiveScopeOverride != null ? ActiveScopeOverride.ShowCutPlane : ShowCutPlane.Value;
-        internal static bool GetShowCutVolume() => ActiveScopeOverride != null ? ActiveScopeOverride.ShowCutVolume : ShowCutVolume.Value;
-        internal static float GetCutVolumeOpacity() => ActiveScopeOverride != null ? ActiveScopeOverride.CutVolumeOpacity : CutVolumeOpacity.Value;
-        internal static string GetCutMode() => ActiveScopeOverride != null ? ActiveScopeOverride.CutMode : CutMode.Value;
-        internal static float GetCylinderRadius() => ActiveScopeOverride != null ? ActiveScopeOverride.CylinderRadius : CylinderRadius.Value;
-        internal static float GetMidCylinderRadius() => ActiveScopeOverride != null ? ActiveScopeOverride.MidCylinderRadius : MidCylinderRadius.Value;
-        internal static float GetMidCylinderPosition() => ActiveScopeOverride != null ? ActiveScopeOverride.MidCylinderPosition : MidCylinderPosition.Value;
-        internal static float GetFarCylinderRadius() => ActiveScopeOverride != null ? ActiveScopeOverride.FarCylinderRadius : FarCylinderRadius.Value;
-        internal static float GetPlane1OffsetMeters() => ActiveScopeOverride != null ? ActiveScopeOverride.Plane1OffsetMeters : Plane1OffsetMeters.Value;
-        internal static float GetPlane2Position() => ActiveScopeOverride != null ? ActiveScopeOverride.Plane2Position : Plane2Position.Value;
+        internal static float GetPlaneOffsetMeters() => ActiveScopeOverride != null ? ActiveScopeOverride.PlaneOffsetMeters : PlaneOffsetMeters;
+        internal static string GetPlaneNormalAxis() => ActiveScopeOverride != null ? ActiveScopeOverride.PlaneNormalAxis : PlaneNormalAxis;
+        internal static float GetCutRadius() => ActiveScopeOverride != null ? ActiveScopeOverride.CutRadius : CutRadius;
+        internal static bool GetShowCutPlane() => ActiveScopeOverride != null ? ActiveScopeOverride.ShowCutPlane : ShowCutPlane;
+        internal static bool GetShowCutVolume() => ActiveScopeOverride != null ? ActiveScopeOverride.ShowCutVolume : ShowCutVolume;
+        internal static float GetCutVolumeOpacity() => ActiveScopeOverride != null ? ActiveScopeOverride.CutVolumeOpacity : CutVolumeOpacity;
+        internal static string GetCutMode() => ActiveScopeOverride != null ? ActiveScopeOverride.CutMode : CutMode;
+        internal static float GetCylinderRadius() => ActiveScopeOverride != null ? ActiveScopeOverride.CylinderRadius : CylinderRadius;
+        internal static float GetMidCylinderRadius() => ActiveScopeOverride != null ? ActiveScopeOverride.MidCylinderRadius : MidCylinderRadius;
+        internal static float GetMidCylinderPosition() => ActiveScopeOverride != null ? ActiveScopeOverride.MidCylinderPosition : MidCylinderPosition;
+        internal static float GetFarCylinderRadius() => ActiveScopeOverride != null ? ActiveScopeOverride.FarCylinderRadius : FarCylinderRadius;
+        internal static float GetPlane1OffsetMeters() => ActiveScopeOverride != null ? ActiveScopeOverride.Plane1OffsetMeters : Plane1OffsetMeters;
+        internal static float GetPlane2Position() => ActiveScopeOverride != null ? ActiveScopeOverride.Plane2Position : Plane2Position;
         internal static float GetPlane2PositionNormalized(float cutLength)
         {
             const float legacyReferenceCutLength = 0.755493f;
@@ -614,22 +374,22 @@ namespace PiPDisabler
             float anchoredDepth = p2LegacyNormalized * legacyReferenceCutLength;
             return cutLength > 1e-5f ? Mathf.Clamp01(anchoredDepth / cutLength) : 0f;
         }
-        internal static float GetPlane2Radius() => ActiveScopeOverride != null ? ActiveScopeOverride.Plane2Radius : Plane2Radius.Value;
-        internal static float GetPlane3Position() => ActiveScopeOverride != null ? ActiveScopeOverride.Plane3Position : Plane3Position.Value;
-        internal static float GetPlane3Radius() => ActiveScopeOverride != null ? ActiveScopeOverride.Plane3Radius : Plane3Radius.Value;
-        internal static float GetPlane4Position() => ActiveScopeOverride != null ? ActiveScopeOverride.Plane4Position : Plane4Position.Value;
-        internal static float GetPlane4Radius() => ActiveScopeOverride != null ? ActiveScopeOverride.Plane4Radius : Plane4Radius.Value;
-        internal static float GetCutStartOffset() => ActiveScopeOverride != null ? ActiveScopeOverride.CutStartOffset : CutStartOffset.Value;
-        internal static float GetCutLength() => ActiveScopeOverride != null ? ActiveScopeOverride.CutLength : CutLength.Value;
-        internal static float GetNearPreserveDepth() => ActiveScopeOverride != null ? ActiveScopeOverride.NearPreserveDepth : NearPreserveDepth.Value;
-        internal static bool GetShowReticle() => ActiveScopeOverride != null ? ActiveScopeOverride.ShowReticle : ShowReticle.Value;
-        internal static float GetReticleBaseSize() => ActiveScopeOverride != null ? ActiveScopeOverride.ReticleBaseSize : ReticleBaseSize.Value;
-        internal static bool GetRestoreOnUnscope() => ActiveScopeOverride != null ? ActiveScopeOverride.RestoreOnUnscope : RestoreOnUnscope.Value;
-        internal static bool GetExpandSearchToWeaponRoot() => ActiveScopeOverride != null ? ActiveScopeOverride.ExpandSearchToWeaponRoot : ExpandSearchToWeaponRoot.Value;
-        internal static bool GetDebugShowHousingMask() => DebugShowHousingMask?.Value ?? false;
-        internal static bool GetDebugLogCutCandidates() => DebugLogCutCandidates?.Value ?? false;
-        internal static bool GetDebugReticleAfterEverything() => DebugReticleAfterEverything?.Value ?? false;
-        internal static bool GetAutoSwitchReticleRenderForNvg() => AutoSwitchReticleRenderForNvg?.Value ?? false;
+        internal static float GetPlane2Radius() => ActiveScopeOverride != null ? ActiveScopeOverride.Plane2Radius : Plane2Radius;
+        internal static float GetPlane3Position() => ActiveScopeOverride != null ? ActiveScopeOverride.Plane3Position : Plane3Position;
+        internal static float GetPlane3Radius() => ActiveScopeOverride != null ? ActiveScopeOverride.Plane3Radius : Plane3Radius;
+        internal static float GetPlane4Position() => ActiveScopeOverride != null ? ActiveScopeOverride.Plane4Position : Plane4Position;
+        internal static float GetPlane4Radius() => ActiveScopeOverride != null ? ActiveScopeOverride.Plane4Radius : Plane4Radius;
+        internal static float GetCutStartOffset() => ActiveScopeOverride != null ? ActiveScopeOverride.CutStartOffset : CutStartOffset;
+        internal static float GetCutLength() => ActiveScopeOverride != null ? ActiveScopeOverride.CutLength : CutLength;
+        internal static float GetNearPreserveDepth() => ActiveScopeOverride != null ? ActiveScopeOverride.NearPreserveDepth : NearPreserveDepth;
+        internal static bool GetShowReticle() => ActiveScopeOverride != null ? ActiveScopeOverride.ShowReticle : ShowReticle;
+        internal static float GetReticleBaseSize() => ActiveScopeOverride != null ? ActiveScopeOverride.ReticleBaseSize : ReticleBaseSize;
+        internal static bool GetRestoreOnUnscope() => ActiveScopeOverride != null ? ActiveScopeOverride.RestoreOnUnscope : RestoreOnUnscope;
+        internal static bool GetExpandSearchToWeaponRoot() => ActiveScopeOverride != null ? ActiveScopeOverride.ExpandSearchToWeaponRoot : ExpandSearchToWeaponRoot;
+        internal static bool GetDebugShowHousingMask() => DebugShowHousingMask;
+        internal static bool GetDebugLogCutCandidates() => DebugLogCutCandidates;
+        internal static bool GetDebugReticleAfterEverything() => DebugReticleAfterEverything;
+        internal static bool GetAutoSwitchReticleRenderForNvg() => AutoSwitchReticleRenderForNvg;
 
         private void OnDestroy()
         {
@@ -640,7 +400,6 @@ namespace PiPDisabler
             PiPDisabler.RestoreAllCameras();
 
             ModEnabled.SettingChanged -= OnModEnabledChanged;
-            EnableWeaponScaling.SettingChanged -= OnWeaponScalingToggled;
             ScopeWhitelistNames.SettingChanged -= OnWhitelistSettingsChanged;
         }
 
@@ -658,22 +417,6 @@ namespace PiPDisabler
             else
             {
                 ScopeLifecycle.SyncState();
-            }
-        }
-
-        /// <summary>
-        /// Handles EnableWeaponScaling toggle mid-session.
-        /// Restore immediately on disable; re-capture on enable while scoped.
-        /// </summary>
-        private static void OnWeaponScalingToggled(object sender, EventArgs e)
-        {
-            if (!EnableWeaponScaling.Value)
-            {
-                Patches.WeaponScalingPatch.RestoreScale();
-            }
-            else if (ScopeLifecycle.IsScoped)
-            {
-                Patches.WeaponScalingPatch.CaptureBaseState();
             }
         }
 
@@ -702,23 +445,6 @@ namespace PiPDisabler
 
             // When mod is disabled, skip ALL per-frame logic
             if (!ModEnabled.Value) return;
-
-            // --- Feature toggle keys ---
-            if (InputProxy.GetKeyDown(MeshSurgeryToggleKey.Value))
-            {
-                EnableMeshSurgery.Value = !EnableMeshSurgery.Value;
-                LogInfo($"Mesh surgery toggled: {EnableMeshSurgery.Value}");
-                if (!EnableMeshSurgery.Value)
-                    MeshSurgeryManager.RestoreAll();
-            }
-
-            if (InputProxy.GetKeyDown(DisablePiPToggleKey.Value))
-            {
-                DisablePiP.Value = !DisablePiP.Value;
-                LogInfo($"Disable PiP toggled: {DisablePiP.Value}");
-                if (!DisablePiP.Value)
-                    PiPDisabler.RestoreAllCameras();
-            }
 
             if (ScopeWhitelistToggleEntryKey.Value != KeyCode.None && InputProxy.GetKeyDown(ScopeWhitelistToggleEntryKey.Value))
             {
@@ -755,22 +481,6 @@ namespace PiPDisabler
                         ? $"[CustomMeshSettings] Deleted custom settings for scope key '{scopeKey}'"
                         : $"[CustomMeshSettings] No custom settings existed for scope key '{scopeKey}'");
                 }
-            }
-
-            if (InputProxy.GetKeyDown(LensesTransparentToggleKey.Value))
-            {
-                MakeLensesTransparent.Value = !MakeLensesTransparent.Value;
-                LogInfo($"Lens transparency toggled: {MakeLensesTransparent.Value}");
-                if (!MakeLensesTransparent.Value)
-                    LensTransparency.RestoreAll();
-            }
-
-            if (ZoomToggleKey.Value != KeyCode.None && InputProxy.GetKeyDown(ZoomToggleKey.Value))
-            {
-                EnableZoom.Value = !EnableZoom.Value;
-                LogInfo($"Zoom toggled: {EnableZoom.Value}");
-                if (!EnableZoom.Value)
-                    ZoomController.Restore();
             }
 
             // --- Diagnostics dump ---
@@ -814,37 +524,7 @@ namespace PiPDisabler
 
         internal static float GetManualLodBiasForCurrentMap()
         {
-            float fallback = ManualLodBias != null ? ManualLodBias.Value : 0f;
-            string locationId = GetCurrentLocationId();
-            if (string.IsNullOrEmpty(locationId) || MapManualLodBias == null)
-                return fallback;
-
-            ConfigEntry<float> entry;
-            if (MapManualLodBias.TryGetValue(locationId, out entry) && entry != null)
-                return entry.Value;
-
-            return fallback;
-        }
-
-        private void BindPerMapLodBias(string configKeySuffix, string mapDisplayName, params string[] locationIds)
-        {
-            if (locationIds == null || locationIds.Length == 0 || string.IsNullOrWhiteSpace(configKeySuffix))
-                return;
-
-            var entry = Config.Bind("2. Zoom Per-Map", $"ManualLodBias_{configKeySuffix}", ManualLodBias.Value,
-                new ConfigDescription(
-                    $"Manual LOD bias override while scoped on map '{mapDisplayName}'.\n" +
-                    "0 = auto (baseLodBias * magnification).\n" +
-                    ">0 = force this exact value (e.g. 4.0).",
-                    new AcceptableValueRange<float>(0f, 20f)));
-
-            for (int i = 0; i < locationIds.Length; i++)
-            {
-                string locationId = locationIds[i];
-                if (string.IsNullOrWhiteSpace(locationId))
-                    continue;
-                MapManualLodBias[locationId] = entry;
-            }
+            return ManualLodBias;
         }
     }
 


### PR DESCRIPTION
### Motivation
- Reduce the config surface to only the requested user-exposed settings and groupings to simplify configuration UI and avoid user confusion. 
- Keep all per-scope custom mesh-surgery authoring settings available as an advanced category while hardcoding global defaults that are not intended for users anymore. 
- Preserve existing behavior by routing runtime logic to constants or per-scope overrides so no functionality is broken by removing the most peripheral config entries.

### Description
- Kept only the requested config surface and groups: `General` (master enable, `ModToggleKey`, `FovAnimationDuration`), `Whitelist` (`ScopeWhitelistNames`, `ScopeWhitelistToggleEntryKey`), `Scope effects` (vignette + shadow settings), `Debug` (`VerboseLogging`, `DiagnosticsKey`), and the full `Custom mesh surgery settings` per-scope authoring set; moved/renamed categories where appropriate. 
- Replaced many former `Config.Bind(...)` entries with internal constants for non-essential settings (PiP toggles, lens transparency, mesh-surgery global defaults, zoom/weapon-scaling/zeroing feature toggles, LOD/culling defaults, and debug-only flags) and updated the plugin getters (e.g. `GetCutMode()`, `GetPlaneOffsetMeters()`) to return constants or per-scope overrides. 
- Removed runtime hotkey handlers and config binds for toggles that were hardcoded (feature toggle hotkeys and per-feature toggle binds were removed), leaving only the retained hotkeys (`ModToggleKey`, whitelist/custom-save/custom-delete, `DiagnosticsKey`). 
- Updated all affected callsites across patches to consume the new constants/getters instead of removed `ConfigEntry` fields (examples: `FovController`, `ZoomController`, `WeaponScalingPatch`, `ZeroingController`, `LensTransparency`, `ScopeLifecycle`, `CameraSettingsManager`, `MeshSurgeryManager`, `ReticleRenderer`, etc.). 

### Testing
- Ran repository checks and searches to verify updated callsites and remaining binds with `rg -n "Config.Bind("` and targeted `rg` queries to locate uses of modified variables (succeeded). 
- Ran `git diff --check` and inspected diffs/stat to validate edits and catch trailing whitespace or obvious merge issues (succeeded). 
- Attempted a build with `dotnet build` but the .NET SDK/CLI is not available in the environment so a full compile could not be performed (failed due to missing `dotnet`). 
- Committed the changes (`git commit`) after local consistency checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b80d31bce0832893fb6e2f54bb680e)