### PR TITLE
Mask reticle to transparent scope lens

### DIFF
--- a/Patches/LensTransparency.cs
+++ b/Patches/LensTransparency.cs
@@ -90,15 +90,8 @@ namespace PiPDisabler
             try
             {
                 var blackMat = GetBlackLensMaterial();
-                int slotCount = 1;
-                try { slotCount = r.sharedMaterials.Length; } catch { }
-                if (slotCount < 1) slotCount = 1;
-
-                var blackArray = new Material[slotCount];
-                for (int i = 0; i < slotCount; i++)
-                    blackArray[i] = blackMat;
-
-                r.sharedMaterials = blackArray;
+                var blackArray = BuildFilledMaterialArray(GetMaterialSlotCount(r), blackMat);
+                ApplyRendererMaterials(r, blackArray, includeInstanced: true);
                 _blackenedRenderers.Add(r);
             }
             catch { }
@@ -120,7 +113,7 @@ namespace PiPDisabler
                 Material[] origMats;
                 if (_trulyOriginalMaterials.TryGetValue(rid, out origMats) && origMats != null)
                 {
-                    try { r.sharedMaterials = origMats; }
+                    try { ApplyRendererMaterials(r, origMats, includeInstanced: true); }
                     catch { }
                 }
             }
@@ -211,7 +204,7 @@ namespace PiPDisabler
 
                 if (e.Renderer != null)
                 {
-                    EnsureTransparentMaterial(e.Renderer);
+                    EnsureTransparentMaterial(e.Renderer, includeInstanced: false);
                 }
             }
         }
@@ -255,7 +248,7 @@ namespace PiPDisabler
                             // Restore original shared materials (legacy path).
                             if (e.OriginalMaterials != null)
                             {
-                                try { e.Renderer.sharedMaterials = e.OriginalMaterials; }
+                                try { ApplyRendererMaterials(e.Renderer, e.OriginalMaterials, includeInstanced: true); }
                                 catch { }
                             }
                             PiPDisablerPlugin.LogVerbose(
@@ -305,27 +298,43 @@ namespace PiPDisabler
             };
             _hidden.Add(entry);
 
-            EnsureTransparentMaterial(r);
+            EnsureTransparentMaterial(r, includeInstanced: true);
 
             PiPDisablerPlugin.LogInfo(
                 $"[LensTransparency] Transparent lens: '{r.gameObject.name}' mats={GetMaterialSlotCount(r)}");
         }
 
-        private static void EnsureTransparentMaterial(Renderer r)
+        private static void EnsureTransparentMaterial(Renderer r, bool includeInstanced)
         {
             if (r == null) return;
             try
             {
                 var transparentMat = GetTransparentLensMaterial();
-                int slotCount = GetMaterialSlotCount(r);
-                var transparentArray = new Material[slotCount];
-                for (int i = 0; i < slotCount; i++)
-                    transparentArray[i] = transparentMat;
-
+                var transparentArray = BuildFilledMaterialArray(GetMaterialSlotCount(r), transparentMat);
                 r.forceRenderingOff = false;
-                r.sharedMaterials = transparentArray;
+                ApplyRendererMaterials(r, transparentArray, includeInstanced);
             }
             catch { }
+        }
+
+        private static Material[] BuildFilledMaterialArray(int slotCount, Material material)
+        {
+            if (slotCount < 1) slotCount = 1;
+
+            var materials = new Material[slotCount];
+            for (int i = 0; i < slotCount; i++)
+                materials[i] = material;
+            return materials;
+        }
+
+        private static void ApplyRendererMaterials(Renderer renderer, Material[] materials, bool includeInstanced)
+        {
+            if (renderer == null || materials == null || materials.Length == 0) return;
+
+            renderer.SetPropertyBlock(null);
+            renderer.sharedMaterials = materials;
+            if (includeInstanced)
+                renderer.materials = materials;
         }
 
         private static int GetMaterialSlotCount(Renderer r)

--- a/Patches/LensTransparency.cs
+++ b/Patches/LensTransparency.cs
@@ -6,49 +6,32 @@ using UnityEngine;
 namespace PiPDisabler
 {
     /// <summary>
-    /// Makes scope lens surfaces invisible by REPLACING THEIR MESH with an empty mesh
-    /// AND forcing material properties to transparent as belt-and-suspenders.
-    ///
-    /// Why previous approaches failed:
-    ///   - renderer.enabled = false:      EFT re-enables it, or CommandBuffer ignores it
-    ///   - forceRenderingOff = true:       CommandBuffer/Graphics.DrawMesh bypasses this
-    ///   - gameObject.SetActive(false):    EFT re-activates, or object was already inactive
-    ///   - gameObject.layer = 31:          Graphics.DrawMesh ignores layers
-    ///   - material swap to transparent:   CommandBuffer uses cached material reference
-    ///
-    /// What works: set MeshFilter.mesh to an EMPTY mesh.
-    ///   No vertices = no triangles = nothing to draw.
-    ///   CommandBuffer, Graphics.DrawMesh, DrawRenderer ALL need geometry.
-    ///   Zero geometry = zero rendering. Period.
-    ///
-    /// v4.7 additions:
-    ///   - Broader IsLensSurface detection (glass, frontlens, material name matching)
-    ///   - Material property forcing (_Color alpha=0, _SwitchToSight=0) as fallback
-    ///   - Expanded search root (climbs through mod_scope/mount parents like MeshSurgeryManager)
-    ///   - EnsureHidden now accepts an exclusion renderer so it always runs even when
-    ///     while scoped.
+    /// Makes scope lens surfaces invisible by swapping them to transparent materials
+    /// while keeping the lens geometry alive for reticle masking.
     /// </summary>
     internal static class LensTransparency
     {
         private struct HiddenEntry
         {
-            public MeshFilter Filter;
-            public SkinnedMeshRenderer Skinned;
-            public Mesh OriginalMesh;
             public Renderer Renderer;
-            public bool WasEnabled;
             public bool WasForceOff;
-            public Material[] OriginalMaterials; // saved for property restore
+            public Material[] OriginalMaterials;
         }
 
         private static readonly List<HiddenEntry> _hidden = new List<HiddenEntry>(16);
-        private static Mesh _emptyMesh;
-
         // Shader property IDs (cached for perf)
         private static readonly int _propColor = Shader.PropertyToID("_Color");
         private static readonly int _propSwitchToSight = Shader.PropertyToID("_SwitchToSight");
+        private static readonly int _propMode = Shader.PropertyToID("_Mode");
+        private static readonly int _propSrcBlend = Shader.PropertyToID("_SrcBlend");
+        private static readonly int _propDstBlend = Shader.PropertyToID("_DstBlend");
+        private static readonly int _propZWrite = Shader.PropertyToID("_ZWrite");
+        private static readonly int _propAlphaClip = Shader.PropertyToID("_AlphaClip");
+        private static readonly int _propSurface = Shader.PropertyToID("_Surface");
+        private static readonly int _propBlend = Shader.PropertyToID("_Blend");
+        private static readonly int _propCull = Shader.PropertyToID("_Cull");
 
-        // Truly original materials per renderer, stored once on first KillMesh call.
+        // Truly original materials per renderer, stored once on first hide call.
         // Prevents the black material we apply on RestoreAll from being mistaken for
         // the original if the player scopes in again on the same session.
         private static readonly Dictionary<int, Material[]> _trulyOriginalMaterials =
@@ -61,15 +44,7 @@ namespace PiPDisabler
 
         // Solid black unlit material applied to lens surfaces when unscoped.
         private static Material _blackLensMaterial;
-
-        private static Mesh GetEmptyMesh()
-        {
-            if (_emptyMesh != null) return _emptyMesh;
-            _emptyMesh = new Mesh();
-            _emptyMesh.name = "EmptyLensMesh";
-            // Zero vertices, zero triangles. Nothing to render.
-            return _emptyMesh;
-        }
+        private static Material _transparentLensMaterial;
 
         private static Material GetBlackLensMaterial()
         {
@@ -83,6 +58,26 @@ namespace PiPDisabler
                 color = Color.black,
             };
             return _blackLensMaterial;
+        }
+
+        private static Material GetTransparentLensMaterial()
+        {
+            if (_transparentLensMaterial != null) return _transparentLensMaterial;
+
+            var shader =
+                Shader.Find("Unlit/Transparent") ??
+                Shader.Find("Sprites/Default") ??
+                Shader.Find("Legacy Shaders/Transparent/Diffuse") ??
+                Shader.Find("Standard");
+
+            _transparentLensMaterial = new Material(shader)
+            {
+                name = "PiPDisabler_TransparentLens",
+                color = new Color(1f, 1f, 1f, 0f),
+                renderQueue = 3000,
+            };
+            ConfigureTransparentMaterial(_transparentLensMaterial);
+            return _transparentLensMaterial;
         }
 
         /// <summary>
@@ -141,6 +136,7 @@ namespace PiPDisabler
         /// </summary>
         public static void FullRestoreAll()
         {
+            RestoreAll();
             RestoreBlackLensMaterials(); // also clears _blackenedRenderers
             _trulyOriginalMaterials.Clear();
             PiPDisablerPlugin.LogInfo(
@@ -148,9 +144,8 @@ namespace PiPDisabler
         }
 
         /// <summary>
-        /// Called on scope enter. Finds and removes geometry from ALL lens surfaces.
-        /// Now searches from an expanded root (same logic as MeshSurgeryManager) to
-        /// catch glass/lens meshes that live above scopeRoot in the hierarchy.
+        /// Called on scope enter. Finds all visible lens surfaces and swaps them to a
+        /// transparent material so the geometry can still be used as a reticle mask.
         /// </summary>
         public static void HideAllLensSurfaces(OpticSight os)
         {
@@ -165,52 +160,47 @@ namespace PiPDisabler
             // Always dump hierarchy on first enter
             DumpHierarchy(searchRoot);
 
-            // Kill only ACTIVE lens renderers (prevents nuking inactive sibling modes on hybrids)
+            // Hide only active lens renderers so inactive sibling modes remain untouched.
             var allRenderers = searchRoot.GetComponentsInChildren<Renderer>(true);
-            int killed = 0;
+            int hidden = 0;
             foreach (var r in allRenderers)
             {
                 if (r == null) continue;
                 if (!r.gameObject.activeInHierarchy) continue;
                 if (IsLensSurface(r) && !ShouldSkipForCollimator(r))
                 {
-                    KillMesh(r);
-                    killed++;
+                    HideLensRenderer(r);
+                    hidden++;
                 }
             }
 
-            // Also kill the specific LensRenderer (belt-and-suspenders)
+            // Also hide the specific LensRenderer.
             try
             {
                 var lens = os.LensRenderer;
                 if (lens != null && lens.gameObject.activeInHierarchy && !ShouldSkipForCollimator(lens))
                 {
-                    KillMesh(lens);
-                    killed++;
+                    HideLensRenderer(lens);
+                    hidden++;
                 }
             }
             catch { }
 
             PiPDisablerPlugin.LogInfo(
-                $"[LensTransparency] Destroyed geometry on {killed} lens surfaces (searchRoot='{searchRoot.name}')");
+                $"[LensTransparency] Applied transparent lens material to {hidden} surfaces (searchRoot='{searchRoot.name}')");
         }
 
         /// <summary>
-        /// Per-frame: re-apply empty mesh if EFT somehow restores geometry.
-        /// Also keep renderer disabled as secondary measure.
+        /// Per-frame: re-apply the transparent lens material if EFT restores the
+        /// original shared materials while the scope is active.
         ///
         /// Accepts an optional exclusion renderer (the ZoomController's managed lens)
         /// so this can safely run every frame while scoped.
         ///
-        /// NOTE: ForceMaterialTransparent is intentionally NOT called here per-frame.
-        /// r.materials allocates new material instances every call → massive GC pressure.
-        /// The mesh is already empty (zero geometry = nothing to draw) and
-        /// forceRenderingOff = true is set, so material forcing is unnecessary.
-        /// Materials are forced once during KillMesh().
+        /// Uses shared materials only, so it stays allocation-free during the scoped loop.
         /// </summary>
         public static void EnsureHidden(Renderer excludeRenderer = null)
         {
-            var emptyMesh = GetEmptyMesh();
             for (int i = 0; i < _hidden.Count; i++)
             {
                 var e = _hidden[i];
@@ -219,23 +209,9 @@ namespace PiPDisabler
                 if (excludeRenderer != null && e.Renderer == excludeRenderer)
                     continue;
 
-                if (e.Skinned != null && e.Skinned.sharedMesh != emptyMesh)
-                {
-                    e.Skinned.sharedMesh = emptyMesh;
-                    PiPDisablerPlugin.LogVerbose(
-                        $"[LensTransparency] Re-emptied skinned mesh on '{e.Skinned.gameObject.name}'");
-                }
-                else if (e.Filter != null && e.Filter.sharedMesh != emptyMesh)
-                {
-                    e.Filter.sharedMesh = emptyMesh;
-                    PiPDisablerPlugin.LogVerbose(
-                        $"[LensTransparency] Re-emptied mesh on '{e.Filter.gameObject.name}'");
-                }
                 if (e.Renderer != null)
                 {
-                    // Re-enforce forceRenderingOff (lightweight bool check, no alloc)
-                    if (!e.Renderer.forceRenderingOff)
-                        e.Renderer.forceRenderingOff = true;
+                    EnsureTransparentMaterial(e.Renderer);
                 }
             }
         }
@@ -263,23 +239,8 @@ namespace PiPDisabler
                 var e = _hidden[i];
                 try
                 {
-                    // Restore original mesh geometry so the lens body is visible again.
-                    if (e.Skinned != null && e.OriginalMesh != null)
-                    {
-                        e.Skinned.sharedMesh = e.OriginalMesh;
-                        PiPDisablerPlugin.LogVerbose(
-                            $"[LensTransparency] Restored skinned mesh on '{e.Skinned.gameObject.name}' → {e.OriginalMesh.vertexCount} verts");
-                    }
-                    else if (e.Filter != null && e.OriginalMesh != null)
-                    {
-                        e.Filter.sharedMesh = e.OriginalMesh;
-                        PiPDisablerPlugin.LogVerbose(
-                            $"[LensTransparency] Restored mesh on '{e.Filter.gameObject.name}' → {e.OriginalMesh.vertexCount} verts");
-                    }
-
                     if (e.Renderer != null)
                     {
-                        // Re-enable rendering (lens is visible when unscoped).
                         e.Renderer.forceRenderingOff = e.WasForceOff;
 
                         if (blackLens)
@@ -306,35 +267,20 @@ namespace PiPDisabler
             }
 
             PiPDisablerPlugin.LogInfo(
-                $"[LensTransparency] Restored {_hidden.Count} lens meshes" +
+                $"[LensTransparency] Restored {_hidden.Count} lens renderers" +
                 (blackLens ? " (black lens applied)" : ""));
             _hidden.Clear();
         }
 
         // ===== Core =====
 
-        private static void KillMesh(Renderer r)
+        private static void HideLensRenderer(Renderer r)
         {
             if (r == null) return;
 
             // Already tracked?
             for (int i = 0; i < _hidden.Count; i++)
                 if (_hidden[i].Renderer == r) return;
-
-            var mf = r.GetComponent<MeshFilter>();
-            var smr = r as SkinnedMeshRenderer;
-            Mesh origMesh = null;
-
-            if (smr != null)
-            {
-                origMesh = smr.sharedMesh;
-                smr.sharedMesh = GetEmptyMesh();
-            }
-            else if (mf != null)
-            {
-                origMesh = mf.sharedMesh;
-                mf.sharedMesh = GetEmptyMesh();
-            }
 
             // Save the TRULY ORIGINAL shared materials only on first encounter.
             // On subsequent scope-ins the renderer may already have the black material
@@ -353,67 +299,80 @@ namespace PiPDisabler
 
             var entry = new HiddenEntry
             {
-                Filter = mf,
-                Skinned = smr,
-                OriginalMesh = origMesh,
                 Renderer = r,
-                WasEnabled = r.enabled,
                 WasForceOff = r.forceRenderingOff,
                 OriginalMaterials = origMats,
             };
             _hidden.Add(entry);
 
-            // Keep renderer enabled state untouched; hybrid sights can manage this
-            // dynamically between optic/collimator modes.
-            r.forceRenderingOff = true;
-
-            // Force material properties to transparent as tertiary kill switch.
-            // This catches cases where EFT uses Graphics.DrawMesh with the material
-            // reference — even with empty mesh, the material state gets cleaned up.
-            ForceMaterialTransparent(r);
+            EnsureTransparentMaterial(r);
 
             PiPDisablerPlugin.LogInfo(
-                $"[LensTransparency] MESH DESTROYED: '{r.gameObject.name}' " +
-                $"(had {(origMesh != null ? origMesh.vertexCount.ToString() : "?")} verts → 0) " +
-                $"MeshFilter={(mf != null ? "yes" : "NO")}, Skinned={(smr != null ? "yes" : "NO")}");
+                $"[LensTransparency] Transparent lens: '{r.gameObject.name}' mats={GetMaterialSlotCount(r)}");
         }
 
-        /// <summary>
-        /// Force all materials on a renderer to be fully transparent.
-        /// Belt-and-suspenders: even if EFT's CommandBuffer re-enables the mesh,
-        /// the material will render nothing visible.
-        /// </summary>
-        private static void ForceMaterialTransparent(Renderer r)
+        private static void EnsureTransparentMaterial(Renderer r)
         {
             if (r == null) return;
             try
             {
-                var mats = r.materials; // creates instances (safe to modify)
-                bool changed = false;
-                for (int i = 0; i < mats.Length; i++)
-                {
-                    var m = mats[i];
-                    if (m == null) continue;
+                var transparentMat = GetTransparentLensMaterial();
+                int slotCount = GetMaterialSlotCount(r);
+                var transparentArray = new Material[slotCount];
+                for (int i = 0; i < slotCount; i++)
+                    transparentArray[i] = transparentMat;
 
-                    if (m.HasProperty(_propColor))
-                    {
-                        m.SetColor(_propColor, new Color(0, 0, 0, 0));
-                        changed = true;
-                    }
-
-                    if (m.HasProperty(_propSwitchToSight))
-                    {
-                        m.SetFloat(_propSwitchToSight, 0f);
-                        changed = true;
-                    }
-
-                    // Force transparent render queue so it can't occlude anything
-                    m.renderQueue = 4000;
-                }
-                if (changed)
-                    r.materials = mats;
+                r.forceRenderingOff = false;
+                r.sharedMaterials = transparentArray;
             }
             catch { }
+        }
+
+        private static int GetMaterialSlotCount(Renderer r)
+        {
+            if (r == null) return 1;
+            try
+            {
+                int slotCount = r.sharedMaterials != null ? r.sharedMaterials.Length : 0;
+                return slotCount > 0 ? slotCount : 1;
+            }
+            catch
+            {
+                return 1;
+            }
+        }
+
+        private static void ConfigureTransparentMaterial(Material material)
+        {
+            if (material == null) return;
+
+            if (material.HasProperty(_propColor))
+                material.SetColor(_propColor, new Color(1f, 1f, 1f, 0f));
+            if (material.HasProperty(_propSwitchToSight))
+                material.SetFloat(_propSwitchToSight, 0f);
+            if (material.HasProperty(_propMode))
+                material.SetFloat(_propMode, 3f);
+            if (material.HasProperty(_propSrcBlend))
+                material.SetInt(_propSrcBlend, (int)UnityEngine.Rendering.BlendMode.SrcAlpha);
+            if (material.HasProperty(_propDstBlend))
+                material.SetInt(_propDstBlend, (int)UnityEngine.Rendering.BlendMode.OneMinusSrcAlpha);
+            if (material.HasProperty(_propZWrite))
+                material.SetInt(_propZWrite, 0);
+            if (material.HasProperty(_propAlphaClip))
+                material.SetFloat(_propAlphaClip, 0f);
+            if (material.HasProperty(_propSurface))
+                material.SetFloat(_propSurface, 1f);
+            if (material.HasProperty(_propBlend))
+                material.SetFloat(_propBlend, 0f);
+            if (material.HasProperty(_propCull))
+                material.SetFloat(_propCull, (float)UnityEngine.Rendering.CullMode.Off);
+
+            material.DisableKeyword("_ALPHATEST_ON");
+            material.EnableKeyword("_ALPHABLEND_ON");
+            material.DisableKeyword("_ALPHAPREMULTIPLY_ON");
+            material.DisableKeyword("_SURFACE_TYPE_OPAQUE");
+            material.EnableKeyword("_SURFACE_TYPE_TRANSPARENT");
+            material.renderQueue = 3000;
         }
 
         /// <summary>
@@ -427,7 +386,7 @@ namespace PiPDisabler
         ///
         /// Uses OrdinalIgnoreCase to avoid ToLowerInvariant() string allocations.
         /// </summary>
-        private static bool IsLensSurface(Renderer r)
+        internal static bool IsLensSurface(Renderer r)
         {
             // --- Layer 1: GameObject name ---
             var goName = r.gameObject.name;
@@ -490,6 +449,19 @@ namespace PiPDisabler
             catch { }
 
             return false;
+        }
+
+        internal static bool IsLensMeshFilter(MeshFilter mf)
+        {
+            if (mf == null) return false;
+
+            var renderer = mf.GetComponent<Renderer>();
+            if (renderer != null && IsLensSurface(renderer))
+                return true;
+
+            string goName = mf.gameObject != null ? mf.gameObject.name : string.Empty;
+            string meshName = mf.sharedMesh != null ? mf.sharedMesh.name : string.Empty;
+            return LooksLikeLensName(goName) || LooksLikeLensName(meshName);
         }
 
         /// <summary>Zero-allocation case-insensitive Contains.</summary>
@@ -627,6 +599,39 @@ namespace PiPDisabler
 
             PiPDisablerPlugin.LogInfo(
                 $"[LensTransparency] CollectHousingRenderers: {result.Count} renderer(s)" +
+                $" (searchRoot='{searchRoot?.name ?? "null"}' from '{os.name}')");
+
+            return result;
+        }
+
+        /// <summary>
+        /// Returns active lens renderers that still have geometry and should define the
+        /// reticle visibility window.
+        /// </summary>
+        public static List<Renderer> CollectLensRenderers(OpticSight os)
+        {
+            var result = new List<Renderer>();
+            if (os == null) return result;
+
+            Transform searchRoot = FindScopeSearchRoot(os.transform);
+            var allRenderers = searchRoot.GetComponentsInChildren<Renderer>(true);
+            foreach (var r in allRenderers)
+            {
+                if (r == null) continue;
+                if (!r.gameObject.activeInHierarchy) continue;
+                if (!IsLensSurface(r)) continue;
+                if (ShouldSkipForCollimator(r)) continue;
+
+                var mf = r.GetComponent<MeshFilter>();
+                var smr = r as SkinnedMeshRenderer;
+                Mesh mesh = mf?.sharedMesh ?? smr?.sharedMesh;
+                if (mesh == null || mesh.vertexCount == 0) continue;
+
+                result.Add(r);
+            }
+
+            PiPDisablerPlugin.LogInfo(
+                $"[LensTransparency] CollectLensRenderers: {result.Count} renderer(s)" +
                 $" (searchRoot='{searchRoot?.name ?? "null"}' from '{os.name}')");
 
             return result;

--- a/Patches/MeshSurgeryManager.cs
+++ b/Patches/MeshSurgeryManager.cs
@@ -1192,6 +1192,7 @@ namespace PiPDisabler
             foreach (var mf in searchRoot.GetComponentsInChildren<MeshFilter>(true))
             {
                 if (!mf || !mf.sharedMesh) continue;
+                if (LensTransparency.IsLensMeshFilter(mf)) continue;
                 inspected++;
 
                 string relSearchPath = null;

--- a/Patches/PiPDisabler.cs
+++ b/Patches/PiPDisabler.cs
@@ -86,59 +86,72 @@ internal static void TickBaseOpticCamera()
             }
         }
 
-
-internal static void SetOpticSightEnabled(OpticSight os, bool enabled)
-{
-    if (os == null) return;
-
-    try
-    {
-        if (!enabled)
+        internal static void SetOpticSightEnabled(OpticSight os, bool enabled)
         {
-            // Store baseline once, then force-disable.
-            if (!_opticOrigEnabled.ContainsKey(os))
-                _opticOrigEnabled[os] = os.enabled;
+            if (os == null) return;
 
-            _ignoreOnDisableFrame[os] = Time.frameCount;
-            if (os.enabled) os.enabled = false;
-        }
-        else
-        {
-            if (_opticOrigEnabled.TryGetValue(os, out var wasEnabled))
+            try
             {
-                // Restore to baseline (do not force-enable if baseline was disabled).
-                if (wasEnabled && !os.enabled)
-                    os.enabled = true;
+                if (!enabled)
+                {
+                    if (!_opticOrigEnabled.ContainsKey(os))
+                        _opticOrigEnabled[os] = os.enabled;
 
-                _opticOrigEnabled.Remove(os);
+                    _ignoreOnDisableFrame[os] = Time.frameCount;
+                    if (os.enabled) os.enabled = false;
+                }
+                else
+                {
+                    if (_opticOrigEnabled.TryGetValue(os, out var wasEnabled))
+                    {
+                        if (wasEnabled && !os.enabled)
+                            os.enabled = true;
+
+                        _opticOrigEnabled.Remove(os);
+                    }
+
+                    _ignoreOnDisableFrame.Remove(os);
+                }
+            }
+            catch { }
+        }
+
+        internal static bool ShouldIgnoreOnDisable(OpticSight os)
+        {
+            if (os == null) return false;
+
+            if (_ignoreOnDisableFrame.TryGetValue(os, out var f))
+            {
+                if (f == Time.frameCount)
+                {
+                    _ignoreOnDisableFrame.Remove(os);
+                    return true;
+                }
+
+                if (Time.frameCount - f > 10)
+                    _ignoreOnDisableFrame.Remove(os);
             }
 
-            _ignoreOnDisableFrame.Remove(os);
+            return false;
         }
-    }
-    catch { /* ignore */ }
-}
 
-internal static bool ShouldIgnoreOnDisable(OpticSight os)
-{
-    if (os == null) return false;
-
-    if (_ignoreOnDisableFrame.TryGetValue(os, out var f))
-    {
-        if (f == Time.frameCount)
+        internal static void RestoreAllOpticSightStates()
         {
-            // One-shot suppression (only for the OnDisable we just triggered).
-            _ignoreOnDisableFrame.Remove(os);
-            return true;
+            try
+            {
+                foreach (var kv in _opticOrigEnabled)
+                {
+                    var os = kv.Key;
+                    if (os == null) continue;
+                    if (kv.Value && !os.enabled)
+                        os.enabled = true;
+                }
+            }
+            catch { }
+
+            _opticOrigEnabled.Clear();
+            _ignoreOnDisableFrame.Clear();
         }
-
-        // Stale entry (e.g. scene change) -> clear.
-        if (Time.frameCount - f > 10)
-            _ignoreOnDisableFrame.Remove(os);
-    }
-
-    return false;
-}
 
         private static void TryFindBaseOpticCameras()
         {
@@ -259,21 +272,7 @@ internal static bool ShouldIgnoreOnDisable(OpticSight os)
                 catch { /* ignore */ }
             }
 
-// Restore OpticSight.enabled states we changed.
-try
-{
-    foreach (var kv in _opticOrigEnabled)
-    {
-        var os = kv.Key;
-        if (os == null) continue;
-        if (kv.Value && !os.enabled)
-            os.enabled = true;
-    }
-}
-catch { /* ignore */ }
-
-_opticOrigEnabled.Clear();
-_ignoreOnDisableFrame.Clear();
+            RestoreAllOpticSightStates();
 
             _cams.Clear();
 

--- a/Patches/ReticleRenderer.cs
+++ b/Patches/ReticleRenderer.cs
@@ -46,12 +46,14 @@ namespace PiPDisabler
         private static Texture      _savedMarkTex;
         private static Texture      _savedMaskTex;
 
-        // Stencil masking — housing occlusion
+        // Stencil masking — lens window + housing occlusion
         // UI/Default exposes _Stencil, _StencilComp, _StencilOp, _ColorMask which let us
         // write to the stencil buffer and test against it without a custom shader.
         private static Material            _stencilClearMat;   // full-screen quad: write 0 to stencil
-        private static Material            _housingStencilMat; // housing pass: write 1 to stencil, no colour
+        private static Material            _lensStencilMat;    // lens pass: write 1 to stencil, no colour
+        private static Material            _housingStencilMat; // housing pass: clear stencil inside visible housing
         private static Material            _stencilDebugMat;   // debug overlay: red tint where housing masks
+        private static readonly List<Renderer> _lensRenderers = new List<Renderer>();
         private static readonly List<Renderer> _housingRenderers = new List<Renderer>();
         private static bool                _hasStencilSupport; // true when UI/Default was found
 
@@ -205,6 +207,7 @@ namespace PiPDisabler
         public static void Cleanup()
         {
             Hide();
+            _lensRenderers.Clear();
             _housingRenderers.Clear();
             _debugFrameCount   = 0;
             _savedMarkTex      = null;
@@ -229,21 +232,21 @@ namespace PiPDisabler
         public static Transform OpticTransform => _opticTransform;
 
         /// <summary>
-        /// Provide the scope housing renderers that will be drawn into the stencil
-        /// buffer each frame so the reticle disappears wherever the housing covers it.
-        /// Call after LensTransparency.HideAllLensSurfaces() so lens renderers are
-        /// already empty-meshed and won't end up in the list.
-        /// Pass null or an empty list to disable housing masking.
+        /// Provide the lens-window and housing renderers that define where the reticle
+        /// may be visible.
         /// </summary>
-        public static void SetHousingRenderers(List<Renderer> renderers)
+        public static void SetMaskRenderers(List<Renderer> lensRenderers, List<Renderer> housingRenderers)
         {
+            _lensRenderers.Clear();
             _housingRenderers.Clear();
             _debugFrameCount = 0; // reset so first frames of new scope are logged
-            if (renderers != null)
-                _housingRenderers.AddRange(renderers);
+            if (lensRenderers != null)
+                _lensRenderers.AddRange(lensRenderers);
+            if (housingRenderers != null)
+                _housingRenderers.AddRange(housingRenderers);
 
             PiPDisablerPlugin.LogInfo(
-                $"[Reticle] Housing mask: {_housingRenderers.Count} renderer(s) registered" +
+                $"[Reticle] Mask renderers: lens={_lensRenderers.Count} housing={_housingRenderers.Count}" +
                 $" stencilSupport={_hasStencilSupport}");
         }
 
@@ -403,12 +406,13 @@ namespace PiPDisabler
         /// <summary>
         /// Rebuild the CommandBuffer.
         ///
-        /// When housing renderers are available and UI/Default was found (stencil-capable):
+        /// When lens and housing renderers are available and UI/Default was found:
         ///   1. Clear stencil to 0 with a full-screen clip-space quad.
-        ///   2. Draw housing meshes in world-space, writing 1 to stencil where the housing
-        ///      passes the depth test (i.e. is actually visible).
-        ///   3. Draw the reticle with stencil test NotEqual-1, so it is invisible wherever
-        ///      the housing was just written.
+        ///   2. Draw the lens meshes in world-space, writing 1 to stencil where the lens
+        ///      is visible.
+        ///   3. Draw housing meshes in world-space, writing 0 back to stencil where the
+        ///      housing covers the lens opening.
+        ///   4. Draw the reticle only where stencil == 1.
         ///
         /// Falls back to the original single-draw path when stencil is unavailable or no
         /// housing renderers have been registered.
@@ -436,23 +440,33 @@ namespace PiPDisabler
                 _cmdBuffer.SetViewport(GetSceneViewport(cam));
             }
 
-            bool useStencil = _hasStencilSupport && _housingRenderers.Count > 0
-                              && _stencilClearMat != null && _housingStencilMat != null;
+            bool useStencil = _hasStencilSupport
+                              && _lensRenderers.Count > 0
+                              && _stencilClearMat != null
+                              && _lensStencilMat != null
+                              && _housingStencilMat != null;
 
             // ── Per-frame debug logging (first N frames after scope enter) ────────────
             if (_debugFrameCount < DebugLogFrames)
             {
-                int activeCount = 0;
+                int activeLensCount = 0;
+                int activeHousingCount = 0;
+                for (int i = 0; i < _lensRenderers.Count; i++)
+                {
+                    var r = _lensRenderers[i];
+                    if (r != null && r.gameObject.activeInHierarchy) activeLensCount++;
+                }
                 for (int i = 0; i < _housingRenderers.Count; i++)
                 {
                     var r = _housingRenderers[i];
-                    if (r != null && r.gameObject.activeInHierarchy) activeCount++;
+                    if (r != null && r.gameObject.activeInHierarchy) activeHousingCount++;
                 }
 
                 PiPDisablerPlugin.LogInfo(
                     $"[Reticle] Frame {_debugFrameCount + 1}/{DebugLogFrames}: " +
-                    $"useStencil={useStencil} housingTotal={_housingRenderers.Count} " +
-                    $"housingActive={activeCount} stencilSupport={_hasStencilSupport}");
+                    $"useStencil={useStencil} lensTotal={_lensRenderers.Count} lensActive={activeLensCount} " +
+                    $"housingTotal={_housingRenderers.Count} housingActive={activeHousingCount} " +
+                    $"stencilSupport={_hasStencilSupport}");
                 _debugFrameCount++;
             }
 
@@ -466,7 +480,16 @@ namespace PiPDisabler
                 _cmdBuffer.SetViewProjectionMatrices(Matrix4x4.identity, Matrix4x4.identity);
                 _cmdBuffer.DrawMesh(_reticleMesh, fullScreenMatrix, _stencilClearMat, 0, -1);
 
-                // ── Step 2: write housing to stencil (world-space) ──────────────────
+                // ── Step 2: write visible lens window to stencil (world-space) ──────
+                _cmdBuffer.SetViewProjectionMatrices(cam.worldToCameraMatrix, cam.projectionMatrix);
+                for (int i = 0; i < _lensRenderers.Count; i++)
+                {
+                    var r = _lensRenderers[i];
+                    if (r == null || !r.gameObject.activeInHierarchy) continue;
+                    _cmdBuffer.DrawRenderer(r, _lensStencilMat);
+                }
+
+                // ── Step 3: clear stencil where housing occludes the lens ───────────
                 _cmdBuffer.SetViewProjectionMatrices(cam.worldToCameraMatrix, cam.projectionMatrix);
                 for (int i = 0; i < _housingRenderers.Count; i++)
                 {
@@ -475,17 +498,16 @@ namespace PiPDisabler
                     _cmdBuffer.DrawRenderer(r, _housingStencilMat);
                 }
 
-                // ── Step 3: draw reticle with stencil test (clip-space) ─────────────
+                // ── Step 4: draw reticle with stencil test (clip-space) ─────────────
                 _cmdBuffer.SetViewProjectionMatrices(Matrix4x4.identity, Matrix4x4.identity);
                 _cmdBuffer.DrawMesh(_reticleMesh, _reticleMatrix, _reticleMat, 0, -1);
 
-                // ── Step 4: optional debug overlay — red tint where housing masked ───
-                // Renders anywhere stencil == 1, i.e. every pixel the housing suppressed.
+                // ── Step 5: optional debug overlay — red tint where reticle is clipped ─
                 // Enable via DebugShowHousingMask in BepInEx config.
                 if (PiPDisablerPlugin.GetDebugShowHousingMask()
                     && _stencilDebugMat != null)
                 {
-                    _cmdBuffer.DrawMesh(_reticleMesh, fullScreenMatrix, _stencilDebugMat, 0, -1);
+                    _cmdBuffer.DrawMesh(_reticleMesh, _reticleMatrix, _stencilDebugMat, 0, -1);
                 }
             }
             else
@@ -595,12 +617,11 @@ namespace PiPDisabler
                 _reticleMat.SetInt("_ZTest",  (int)CompareFunction.Always);
                 _reticleMat.SetInt("_ZWrite", 0);
 
-                // ── Stencil test: only draw reticle where housing did NOT write ──────
-                // We use ref=1.  Housing writes 1 → reticle skips those pixels.
+                // ── Stencil test: only draw reticle inside the visible lens window. ───
                 if (_hasStencilSupport)
                 {
                     _reticleMat.SetFloat("_Stencil",          1f);
-                    _reticleMat.SetFloat("_StencilComp",      (float)CompareFunction.NotEqual); // pass ≠ 1
+                    _reticleMat.SetFloat("_StencilComp",      (float)CompareFunction.Equal);
                     _reticleMat.SetFloat("_StencilOp",        (float)StencilOp.Keep);
                     _reticleMat.SetFloat("_StencilReadMask",  255f);
                     _reticleMat.SetFloat("_StencilWriteMask", 0f);   // don't write
@@ -623,9 +644,19 @@ namespace PiPDisabler
                     _stencilClearMat.SetInt("_ZTest",  (int)CompareFunction.Always);
                     _stencilClearMat.SetInt("_ZWrite", 0);
 
-                    // Housing material: world-space pass, writes stencil=1 where depth passes.
+                    // Lens material: world-space pass, writes stencil=1 where depth passes.
+                    _lensStencilMat = new Material(stencilShader) { renderQueue = 4999 };
+                    _lensStencilMat.SetFloat("_Stencil",          1f);
+                    _lensStencilMat.SetFloat("_StencilComp",      (float)CompareFunction.Always);
+                    _lensStencilMat.SetFloat("_StencilOp",        (float)StencilOp.Replace);
+                    _lensStencilMat.SetFloat("_StencilWriteMask", 255f);
+                    _lensStencilMat.SetFloat("_ColorMask",        0f);
+                    _lensStencilMat.SetInt("_ZTest",  (int)CompareFunction.LessEqual);
+                    _lensStencilMat.SetInt("_ZWrite", 0);
+
+                    // Housing material: world-space pass, clears stencil where visible.
                     _housingStencilMat = new Material(stencilShader) { renderQueue = 4999 };
-                    _housingStencilMat.SetFloat("_Stencil",          1f);
+                    _housingStencilMat.SetFloat("_Stencil",          0f);
                     _housingStencilMat.SetFloat("_StencilComp",      (float)CompareFunction.Always);
                     _housingStencilMat.SetFloat("_StencilOp",        (float)StencilOp.Replace);
                     _housingStencilMat.SetFloat("_StencilWriteMask", 255f);
@@ -633,15 +664,14 @@ namespace PiPDisabler
                     _housingStencilMat.SetInt("_ZTest",  (int)CompareFunction.LessEqual); // only where visible
                     _housingStencilMat.SetInt("_ZWrite", 0);
 
-                    // Debug overlay: renders a semi-transparent red tint wherever stencil == 1.
-                    // Reveals which screen regions are being suppressed by the housing mask.
+                    // Debug overlay: renders a semi-transparent red tint wherever stencil == 0.
                     _stencilDebugMat = new Material(stencilShader)
                     {
                         color       = new Color(1f, 0.1f, 0.1f, 0.55f),
                         renderQueue = 5000
                     };
-                    _stencilDebugMat.SetFloat("_Stencil",         1f);
-                    _stencilDebugMat.SetFloat("_StencilComp",     (float)CompareFunction.Equal); // only where housing is
+                    _stencilDebugMat.SetFloat("_Stencil",         0f);
+                    _stencilDebugMat.SetFloat("_StencilComp",     (float)CompareFunction.Equal);
                     _stencilDebugMat.SetFloat("_StencilOp",       (float)StencilOp.Keep);
                     _stencilDebugMat.SetFloat("_StencilReadMask", 255f);
                     _stencilDebugMat.SetInt("_ZTest",  (int)CompareFunction.Always);

--- a/Patches/ScopeDetectionPatches.cs
+++ b/Patches/ScopeDetectionPatches.cs
@@ -38,6 +38,7 @@ namespace PiPDisabler.Patches
                 $"frame={Time.frameCount}");
 
             if (!PiPDisablerPlugin.ModEnabled.Value) return;
+            if (PiPDisabler.ShouldIgnoreOnDisable(__instance)) return;
             ScopeLifecycle.OnOpticDisabled(__instance);
         }
     }

--- a/Patches/ScopeLifecycle.cs
+++ b/Patches/ScopeLifecycle.cs
@@ -214,6 +214,7 @@ namespace PiPDisabler
                 // Re-extract reticle from the NEW mode's linza
                 ReticleRenderer.Cleanup();
                 ReticleRenderer.ExtractReticle(os);
+                PiPDisabler.SetOpticSightEnabled(os, false);
 
                 // Re-hide lenses (the new mode's lens might not be hidden yet)
                 LensTransparency.HideAllLensSurfaces(os);
@@ -773,6 +774,7 @@ namespace PiPDisabler
             ReticleRenderer.Cleanup();
             ScopeEffectsRenderer.Cleanup();
             LensTransparency.RestoreAll();
+            PiPDisabler.RestoreAllOpticSightStates();
             CameraSettingsManager.Restore();
             PiPDisabler.RestoreAllCameras();
 
@@ -822,6 +824,7 @@ namespace PiPDisabler
 
             // 2. Extract reticle texture BEFORE destroying lens mesh
             ReticleRenderer.ExtractReticle(os);
+            PiPDisabler.SetOpticSightEnabled(os, false);
 
             // 3. Hide ALL lens surfaces in the scope hierarchy (once)
             LensTransparency.HideAllLensSurfaces(os);
@@ -903,6 +906,7 @@ namespace PiPDisabler
 
             // 4. Restore lens
             LensTransparency.RestoreAll();
+            PiPDisabler.RestoreAllOpticSightStates();
 
             // 5. Restore camera LOD/culling settings
             CameraSettingsManager.Restore();

--- a/Patches/ScopeLifecycle.cs
+++ b/Patches/ScopeLifecycle.cs
@@ -219,7 +219,9 @@ namespace PiPDisabler
                 LensTransparency.HideAllLensSurfaces(os);
 
                 // Recollect housing + weapon renderers for the new mode's geometry.
-                ReticleRenderer.SetHousingRenderers(CollectStencilRenderers(os));
+                ReticleRenderer.SetMaskRenderers(
+                    LensTransparency.CollectLensRenderers(os),
+                    CollectStencilRenderers(os));
 
                 // Notify FOV controller the mode changed so it re-reads ScopeCameraData
                 FovController.OnModeSwitch();
@@ -826,7 +828,9 @@ namespace PiPDisabler
 
             // 2b. Collect housing + weapon renderers for reticle stencil mask (lens surfaces
             //     are already empty-meshed above, so they won't end up in the list).
-            ReticleRenderer.SetHousingRenderers(CollectStencilRenderers(os));
+            ReticleRenderer.SetMaskRenderers(
+                LensTransparency.CollectLensRenderers(os),
+                CollectStencilRenderers(os));
 
             // 3. Get magnification for reticle scaling and zoom
             float mag = ZoomController.GetMagnification(os);


### PR DESCRIPTION
### Motivation
- Allow seeing through the scoped lens while still using the lens geometry as a stencil mask so the reticle only draws when it is actually inside the lens opening.
- Avoid cutting lens geometry during runtime mesh surgery so the lens can be used for accurate masking instead of being emptied.

### Description
- Swap scoped lens renderers to a shared transparent material instead of replacing their meshes, preserving geometry for stencil masking and keeping original materials for restore/black-lens behavior (`Patches/LensTransparency.cs`).
- Add allocation-free helpers: `GetTransparentLensMaterial`, `EnsureTransparentMaterial`, `ConfigureTransparentMaterial`, `CollectLensRenderers`, and `IsLensMeshFilter` to manage transparent lens materials and identify lens mesh filters (`Patches/LensTransparency.cs`).
- Change reticle CommandBuffer stencil sequence to: clear stencil, draw visible lens geometry (write 1), draw housing (clear/overwrite where housing occludes lens), then draw the reticle only where `stencil == 1`, and updated debug overlay to match the new logic (`Patches/ReticleRenderer.cs`).
- Exclude lens MeshFilters from mesh-cut target discovery by checking `LensTransparency.IsLensMeshFilter(mf)` so mesh surgery does not bore into lens geometry (`Patches/MeshSurgeryManager.cs`).
- Wire the scope enter/mode-switch flow to collect both lens and housing renderers and pass them to the reticle mask API via `ReticleRenderer.SetMaskRenderers(...)` (`Patches/ScopeLifecycle.cs`).

### Testing
- Ran `git diff --check` to validate the working tree and patches; this check passed.
- Attempted `dotnet build PiPDisabler.csproj` to compile the project but the environment lacks the `dotnet` SDK so the build could not be performed here (automated build failed due to missing `dotnet`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba6176d1788328822544884fdedcb6)