### PR TITLE
Add distance-driven scoped LOD bias with raycast detection and per-frame updates

### DIFF
--- a/Patches/CameraSettingsManager.cs
+++ b/Patches/CameraSettingsManager.cs
@@ -255,7 +255,7 @@ namespace PiPDisabler
                 var hitTransform = hit.collider != null ? hit.collider.transform : null;
                 if (hitTransform == null) continue;
                 if (weaponRoot != null && hitTransform.IsChildOf(weaponRoot)) continue;
-                if (localPlayer != null && hitTransform.IsChildOf(localPlayer.transform)) continue;
+                if (localPlayer != null && hitTransform.IsChildOf(localPlayer.Transform)) continue;
                 if (hit.distance <= 0.001f) continue;
 
                 hitDistance = hit.distance;

--- a/Patches/CameraSettingsManager.cs
+++ b/Patches/CameraSettingsManager.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Reflection;
+using EFT;
 using EFT.CameraControl;
 using HarmonyLib;
 using UnityEngine;
@@ -9,9 +10,8 @@ namespace PiPDisabler
     /// <summary>
     /// Swaps main camera LOD bias and culling settings with scope-appropriate values during ADS.
     ///
-    /// When zoomed in, distant objects fill more screen pixels and should render at higher detail.
     /// This manager reads the scope's ScopeCameraData (FieldOfView, FarClipPlane, etc.) and
-    /// increases the LOD bias proportionally to the magnification.
+    /// applies a scoped LOD bias curve driven by the first valid world hit in front of the weapon.
     ///
     /// From Elcan ScopeCameraData:
     ///   FieldOfView = 5.75 (4x mode) / 23 (1x mode)
@@ -21,7 +21,7 @@ namespace PiPDisabler
     ///   OpticCullingMaskScale = 1
     ///
     /// Settings modified:
-    ///   QualitySettings.lodBias          — multiplied by magnification factor
+    ///   QualitySettings.lodBias          — set from the scoped distance curve
     ///   Camera.main.farClipPlane         — set to scope's FarClipPlane if greater
     ///   Camera.layerCullDistances        — adjusted for scope's culling scale
     /// </summary>
@@ -42,6 +42,9 @@ namespace PiPDisabler
         private static FieldInfo _scdCullingMaskField;
         private static FieldInfo _scdCullingScaleField;
         private static bool _scdSearched;
+        private const float RaycastMaxDistance = 2000f;
+        private const float RaycastStartOffset = 0.05f;
+        private const float AutoCurveMaxDistance = 400f;
 
         /// <summary>
         /// Apply scope-optimized camera settings for the active optic.
@@ -86,12 +89,9 @@ namespace PiPDisabler
                 magnification = scopeFov > 0.1f ? 35f / scopeFov : 1f;
 
             // === Apply LOD bias ===
-            // Increase LOD bias proportionally to magnification.
-            // At 4x zoom, objects at distance appear 4x larger → use 4x finer LODs.
-            float manualLodBias = PiPDisablerPlugin.GetManualLodBiasForCurrentMap();
-            float newLodBias = manualLodBias > 0f
-                ? manualLodBias
-                : _savedLodBias * Mathf.Max(magnification, 1f);
+            float hitDistance;
+            bool hasHitDistance;
+            float newLodBias = CalculateScopedLodBias(os, out hitDistance, out hasHitDistance);
             QualitySettings.lodBias = newLodBias;
 
             // Force highest LOD by default unless overridden by manual max LOD level.
@@ -127,7 +127,19 @@ namespace PiPDisabler
 
             PiPDisablerPlugin.LogInfo(
                 $"[CameraSettings] Applied: lodBias {_savedLodBias:F2}→{newLodBias:F2} " +
-                $"(mag={magnification:F1}x) farClip={cam.farClipPlane:F0} maxLOD={appliedMaxLod}");
+                $"(mag={magnification:F1}x, hit={(hasHitDistance ? $"{hitDistance:F1}m" : $">{AutoCurveMaxDistance:F0}m")}) " +
+                $"farClip={cam.farClipPlane:F0} maxLOD={appliedMaxLod}");
+        }
+
+        /// <summary>
+        /// Update the scoped LOD bias while staying ADS.
+        /// </summary>
+        public static void UpdateForOptic(OpticSight os)
+        {
+            if (!_applied || os == null) return;
+
+            float hitDistance;
+            QualitySettings.lodBias = CalculateScopedLodBias(os, out hitDistance, out _);
         }
 
         /// <summary>
@@ -210,6 +222,115 @@ namespace PiPDisabler
 
         private static bool IsOnSameMode(Transform a, Transform b)
             => PiPDisablerPlugin.IsOnSameMode(a, b);
+
+        private static float CalculateScopedLodBias(OpticSight os, out float hitDistance, out bool hasHitDistance)
+        {
+            float manualLodBias = PiPDisablerPlugin.GetManualLodBiasForCurrentMap();
+            if (manualLodBias > 0f)
+            {
+                hitDistance = 0f;
+                hasHitDistance = false;
+                return manualLodBias;
+            }
+
+            hasHitDistance = TryGetWorldHitDistance(os, out hitDistance);
+            float distanceForCurve = hasHitDistance ? hitDistance : AutoCurveMaxDistance;
+            return PiPDisablerPlugin.EvaluateAutoLodBiasForDistance(distanceForCurve);
+        }
+
+        private static bool TryGetWorldHitDistance(OpticSight os, out float hitDistance)
+        {
+            hitDistance = 0f;
+            if (os == null) return false;
+            if (!TryGetWeaponRay(os, out var weaponRoot, out var origin, out var direction)) return false;
+
+            var hits = Physics.RaycastAll(origin, direction, RaycastMaxDistance, ~0, QueryTriggerInteraction.Ignore);
+            if (hits == null || hits.Length == 0) return false;
+
+            Array.Sort(hits, (a, b) => a.distance.CompareTo(b.distance));
+
+            var localPlayer = PiPDisablerPlugin.GetLocalPlayer();
+            foreach (var hit in hits)
+            {
+                var hitTransform = hit.collider != null ? hit.collider.transform : null;
+                if (hitTransform == null) continue;
+                if (weaponRoot != null && hitTransform.IsChildOf(weaponRoot)) continue;
+                if (localPlayer != null && hitTransform.IsChildOf(localPlayer.transform)) continue;
+                if (hit.distance <= 0.001f) continue;
+
+                hitDistance = hit.distance;
+                return true;
+            }
+
+            return false;
+        }
+
+        private static bool TryGetWeaponRay(OpticSight os, out Transform weaponRoot, out Vector3 origin, out Vector3 direction)
+        {
+            weaponRoot = FindWeaponRoot(os.transform);
+            direction = os.transform.forward;
+            origin = Vector3.zero;
+
+            if (weaponRoot == null) return false;
+
+            Transform best = null;
+            float bestScore = float.MinValue;
+
+            foreach (var candidate in weaponRoot.GetComponentsInChildren<Transform>(true))
+            {
+                if (candidate == null) continue;
+
+                float score = ScoreWeaponRayCandidate(candidate.name);
+                if (score < 0f) continue;
+
+                Vector3 delta = candidate.position - weaponRoot.position;
+                float forward = Vector3.Dot(direction, delta);
+                if (forward < -0.05f) continue;
+
+                score += forward;
+                if (score <= bestScore) continue;
+
+                best = candidate;
+                bestScore = score;
+            }
+
+            if (best == null) return false;
+
+            origin = best.position + direction * RaycastStartOffset;
+            return true;
+        }
+
+        private static Transform FindWeaponRoot(Transform from)
+        {
+            if (from == null) return null;
+
+            for (Transform cur = from; cur != null; cur = cur.parent)
+            {
+                string name = cur.name ?? string.Empty;
+                if (string.Equals(name, "weapon", StringComparison.OrdinalIgnoreCase))
+                    return cur;
+                if (name.IndexOf("player", StringComparison.OrdinalIgnoreCase) >= 0
+                    || name.IndexOf("hands", StringComparison.OrdinalIgnoreCase) >= 0
+                    || name.IndexOf("camera", StringComparison.OrdinalIgnoreCase) >= 0)
+                    break;
+            }
+
+            return null;
+        }
+
+        private static float ScoreWeaponRayCandidate(string name)
+        {
+            if (string.IsNullOrEmpty(name)) return -1f;
+
+            string lower = name.ToLowerInvariant();
+            if (lower.Contains("fireport")) return 100f;
+            if (lower.Contains("muzzle")) return 90f;
+            if (lower.Contains("mod_muzzle")) return 85f;
+            if (lower.Contains("barrel")) return 75f;
+            if (lower.Contains("weapon_ln")) return 70f;
+            if (lower.Contains("front")) return 50f;
+            return -1f;
+        }
 
         private static void DiscoverType()
         {

--- a/Patches/CameraSettingsManager.cs
+++ b/Patches/CameraSettingsManager.cs
@@ -255,7 +255,7 @@ namespace PiPDisabler
                 var hitTransform = hit.collider != null ? hit.collider.transform : null;
                 if (hitTransform == null) continue;
                 if (weaponRoot != null && hitTransform.IsChildOf(weaponRoot)) continue;
-                if (localPlayer != null && hitTransform.IsChildOf(localPlayer.Transform)) continue;
+                if (localPlayer != null && hitTransform.IsChildOf(localPlayer.gameObject.transform)) continue;
                 if (hit.distance <= 0.001f) continue;
 
                 hitDistance = hit.distance;

--- a/Patches/ScopeLifecycle.cs
+++ b/Patches/ScopeLifecycle.cs
@@ -389,6 +389,9 @@ namespace PiPDisabler
             // Keep lens hidden (re-kill if EFT restores geometry)
             LensTransparency.EnsureHidden();
 
+            if (_activeOptic != null)
+                CameraSettingsManager.UpdateForOptic(_activeOptic);
+
             // Update reticle position/rotation/scale and effects
             if (_activeOptic != null)
             {

--- a/PiPDisabler.csproj
+++ b/PiPDisabler.csproj
@@ -57,6 +57,10 @@
       <HintPath>..\..\EscapeFromTarkov_Data\Managed\UnityEngine.InputLegacyModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="UnityEngine.PhysicsModule">
+      <HintPath>..\..\EscapeFromTarkov_Data\Managed\UnityEngine.PhysicsModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\..\BepInEx\core\Newtonsoft.Json.dll</HintPath>
       <Private>False</Private>

--- a/PiPDisablerPlugin.cs
+++ b/PiPDisablerPlugin.cs
@@ -214,6 +214,11 @@ namespace PiPDisabler
         internal static ConfigEntry<float> FovAnimationDuration;
         internal static ConfigEntry<KeyCode> ZoomToggleKey;
         internal static ConfigEntry<float> ManualLodBias;
+        internal static ConfigEntry<float> AutoLodBiasAt50m;
+        internal static ConfigEntry<float> AutoLodBiasAt100m;
+        internal static ConfigEntry<float> AutoLodBiasAt200m;
+        internal static ConfigEntry<float> AutoLodBiasAt300m;
+        internal static ConfigEntry<float> AutoLodBiasAt400m;
         internal static ConfigEntry<int> ManualMaximumLodLevel;
         internal static ConfigEntry<float> ManualCullingMultiplier;
         internal static Dictionary<string, ConfigEntry<float>> MapManualLodBias;
@@ -359,8 +364,33 @@ namespace PiPDisabler
             ManualLodBias = Config.Bind("Optimization", "ManualLodBias", 4.0f,
                 new ConfigDescription(
                     "Manual LOD bias while scoped.\n" +
-                    "0 = auto (baseLodBias * magnification).\n" +
+                    "0 = auto (range curve).\n" +
                     ">0 = force this exact value (e.g. 4.0).",
+                    new AcceptableValueRange<float>(0f, 20f),
+                    new ConfigurationManagerAttributes { IsAdvanced = true }));
+            AutoLodBiasAt50m = Config.Bind("Optimization", "AutoLodBiasAt50m", 2.0f,
+                new ConfigDescription(
+                    "Auto scoped LOD bias at 50 meters.",
+                    new AcceptableValueRange<float>(0f, 20f),
+                    new ConfigurationManagerAttributes { IsAdvanced = true }));
+            AutoLodBiasAt100m = Config.Bind("Optimization", "AutoLodBiasAt100m", 2.75f,
+                new ConfigDescription(
+                    "Auto scoped LOD bias at 100 meters.",
+                    new AcceptableValueRange<float>(0f, 20f),
+                    new ConfigurationManagerAttributes { IsAdvanced = true }));
+            AutoLodBiasAt200m = Config.Bind("Optimization", "AutoLodBiasAt200m", 3.5f,
+                new ConfigDescription(
+                    "Auto scoped LOD bias at 200 meters.",
+                    new AcceptableValueRange<float>(0f, 20f),
+                    new ConfigurationManagerAttributes { IsAdvanced = true }));
+            AutoLodBiasAt300m = Config.Bind("Optimization", "AutoLodBiasAt300m", 4.25f,
+                new ConfigDescription(
+                    "Auto scoped LOD bias at 300 meters.",
+                    new AcceptableValueRange<float>(0f, 20f),
+                    new ConfigurationManagerAttributes { IsAdvanced = true }));
+            AutoLodBiasAt400m = Config.Bind("Optimization", "AutoLodBiasAt400m", 5.0f,
+                new ConfigDescription(
+                    "Auto scoped LOD bias at 400 meters and beyond.",
                     new AcceptableValueRange<float>(0f, 20f),
                     new ConfigurationManagerAttributes { IsAdvanced = true }));
             ManualMaximumLodLevel = Config.Bind("Optimization", "ManualMaximumLodLevel", -1,
@@ -1055,16 +1085,36 @@ namespace PiPDisabler
 
         internal static float GetManualLodBiasForCurrentMap()
         {
-            float fallback = ManualLodBias != null ? ManualLodBias.Value : 0f;
+            float globalOverride = ManualLodBias != null ? ManualLodBias.Value : 0f;
+            if (globalOverride > 0f)
+                return globalOverride;
+
             string locationId = GetCurrentLocationId();
             if (string.IsNullOrEmpty(locationId) || MapManualLodBias == null)
-                return fallback;
+                return 0f;
 
             ConfigEntry<float> entry;
             if (MapManualLodBias.TryGetValue(locationId, out entry) && entry != null)
                 return entry.Value;
 
-            return fallback;
+            return 0f;
+        }
+
+        internal static float EvaluateAutoLodBiasForDistance(float distanceMeters)
+        {
+            float d = Mathf.Max(0f, distanceMeters);
+            float v50 = AutoLodBiasAt50m.Value;
+            float v100 = AutoLodBiasAt100m.Value;
+            float v200 = AutoLodBiasAt200m.Value;
+            float v300 = AutoLodBiasAt300m.Value;
+            float v400 = AutoLodBiasAt400m.Value;
+
+            if (d <= 50f) return v50;
+            if (d <= 100f) return Mathf.Lerp(v50, v100, Mathf.InverseLerp(50f, 100f, d));
+            if (d <= 200f) return Mathf.Lerp(v100, v200, Mathf.InverseLerp(100f, 200f, d));
+            if (d <= 300f) return Mathf.Lerp(v200, v300, Mathf.InverseLerp(200f, 300f, d));
+            if (d <= 400f) return Mathf.Lerp(v300, v400, Mathf.InverseLerp(300f, 400f, d));
+            return v400;
         }
 
         private void BindPerMapLodBias(string configKeySuffix, string mapDisplayName, params string[] locationIds)


### PR DESCRIPTION
### Motivation

- Replace the previous simple magnification-based LOD multiplier with an automatic LOD bias curve driven by the first valid world hit in front of the weapon to better match visual detail to actual target distance. 
- Provide per-frame updates while ADS so LOD bias adapts to aim changes during freelook/rotation and mode switches. 

### Description

- Implemented a scoped LOD system that raycasts from the weapon muzzle to find the first non-weapon, non-player hit and evaluates an auto LOD bias curve from that distance via `EvaluateAutoLodBiasForDistance`.
- Added helper functions `CalculateScopedLodBias`, `TryGetWorldHitDistance`, `TryGetWeaponRay`, `FindWeaponRoot`, and `ScoreWeaponRayCandidate`, plus constants controlling raycast ranges and offsets.
- Introduced new configuration entries `AutoLodBiasAt50m`, `AutoLodBiasAt100m`, `AutoLodBiasAt200m`, `AutoLodBiasAt300m`, and `AutoLodBiasAt400m`, and changed `ManualLodBias` semantics so `0` now means use the auto range curve.
- Wire per-frame updates by adding `UpdateForOptic` and calling it from `ScopeLifecycle.Tick`, adjusted logging and fallback behavior in `GetManualLodBiasForCurrentMap` to prefer per-map/global overrides when set.

### Testing

- No automated tests were added for this change and no automated test suite was executed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba660734ec832887f2bda76153c2a7)