### PR TITLE
Add distance-based LOD bias adjustment for scoped views

### DIFF
--- a/Patches/CameraSettingsManager.cs
+++ b/Patches/CameraSettingsManager.cs
@@ -155,6 +155,23 @@ namespace PiPDisabler
         }
 
         /// <summary>
+        /// Per-frame LOD bias update driven by DistanceLodBiasController.
+        /// Only writes QualitySettings.lodBias — all other camera settings
+        /// (far clip, cull distances, max LOD level) remain as set by ApplyForOptic.
+        /// </summary>
+        public static void UpdateDistanceLodBias()
+        {
+            if (!_applied) return;
+            if (PiPDisablerPlugin.EnableDistanceLodBias == null ||
+                !PiPDisablerPlugin.EnableDistanceLodBias.Value)
+                return;
+
+            float bias = DistanceLodBiasController.CurrentLodBias;
+            if (bias > 0f)
+                QualitySettings.lodBias = bias;
+        }
+
+        /// <summary>
         /// Try to read ScopeCameraData from the scope hierarchy via reflection.
         /// </summary>
         private static bool TryGetScopeCameraData(OpticSight os, out float fov, out float farClip)

--- a/Patches/DistanceLodBiasController.cs
+++ b/Patches/DistanceLodBiasController.cs
@@ -1,0 +1,104 @@
+using UnityEngine;
+
+namespace PiPDisabler
+{
+    /// <summary>
+    /// Raycasts from the aiming camera each frame while scoped and remaps the
+    /// hit distance to a LOD bias value using a piecewise-linear curve defined
+    /// by five runtime-configurable breakpoints (50 m, 100 m, 200 m, 300 m, 400 m).
+    ///
+    /// Close targets get a higher LOD bias (more detail), distant targets get less.
+    /// When the raycast misses (sky / beyond max range), the 400 m value is used.
+    /// </summary>
+    internal static class DistanceLodBiasController
+    {
+        // Cached result updated every Tick().
+        private static float _currentLodBias;
+        private static float _currentDistance;
+        private static bool _hasHit;
+
+        // Max raycast range — anything beyond this uses the 400 m bias.
+        private const float MaxRaycastDistance = 600f;
+
+        /// <summary>
+        /// The LOD bias computed from the last raycast. Only meaningful when
+        /// <see cref="PiPDisablerPlugin.EnableDistanceLodBias"/> is true and
+        /// the scope is active.
+        /// </summary>
+        public static float CurrentLodBias => _currentLodBias;
+
+        /// <summary>Distance to the aimed-at surface (0 if no hit).</summary>
+        public static float CurrentDistance => _currentDistance;
+
+        /// <summary>Whether the last raycast hit anything.</summary>
+        public static bool HasHit => _hasHit;
+
+        /// <summary>
+        /// Call once per frame while scoped. Performs the raycast and updates
+        /// <see cref="CurrentLodBias"/>.
+        /// </summary>
+        public static void Tick()
+        {
+            if (PiPDisablerPlugin.EnableDistanceLodBias == null ||
+                !PiPDisablerPlugin.EnableDistanceLodBias.Value)
+                return;
+
+            var cam = PiPDisablerPlugin.GetMainCamera();
+            if (cam == null) return;
+
+            var ray = new Ray(cam.transform.position, cam.transform.forward);
+
+            int mask = PiPDisablerPlugin.DistanceLodBiasRaycastMask != null
+                ? PiPDisablerPlugin.DistanceLodBiasRaycastMask.Value
+                : 0;
+            // Negative value convention: treat as ~abs(value) to exclude layers.
+            if (mask < 0) mask = ~(-mask);
+            if (mask == 0) mask = ~0; // all layers
+
+            RaycastHit hit;
+            if (Physics.Raycast(ray, out hit, MaxRaycastDistance, mask, QueryTriggerInteraction.Ignore))
+            {
+                _hasHit = true;
+                _currentDistance = hit.distance;
+            }
+            else
+            {
+                _hasHit = false;
+                _currentDistance = MaxRaycastDistance;
+            }
+
+            _currentLodBias = EvaluateLodBias(_currentDistance);
+        }
+
+        /// <summary>
+        /// Reset state when leaving scope.
+        /// </summary>
+        public static void Reset()
+        {
+            _currentLodBias = 0f;
+            _currentDistance = 0f;
+            _hasHit = false;
+        }
+
+        /// <summary>
+        /// Piecewise-linear interpolation across the five configurable breakpoints.
+        /// Distances &lt;= 50 m clamp to the 50 m value; distances &gt;= 400 m clamp
+        /// to the 400 m value.
+        /// </summary>
+        private static float EvaluateLodBias(float distance)
+        {
+            float v50  = PiPDisablerPlugin.DistanceLodBias_50m  != null ? PiPDisablerPlugin.DistanceLodBias_50m.Value  : 6f;
+            float v100 = PiPDisablerPlugin.DistanceLodBias_100m != null ? PiPDisablerPlugin.DistanceLodBias_100m.Value : 5f;
+            float v200 = PiPDisablerPlugin.DistanceLodBias_200m != null ? PiPDisablerPlugin.DistanceLodBias_200m.Value : 4f;
+            float v300 = PiPDisablerPlugin.DistanceLodBias_300m != null ? PiPDisablerPlugin.DistanceLodBias_300m.Value : 3f;
+            float v400 = PiPDisablerPlugin.DistanceLodBias_400m != null ? PiPDisablerPlugin.DistanceLodBias_400m.Value : 2f;
+
+            if (distance <= 50f)  return v50;
+            if (distance <= 100f) return Mathf.Lerp(v50,  v100, Mathf.InverseLerp(50f,  100f, distance));
+            if (distance <= 200f) return Mathf.Lerp(v100, v200, Mathf.InverseLerp(100f, 200f, distance));
+            if (distance <= 300f) return Mathf.Lerp(v200, v300, Mathf.InverseLerp(200f, 300f, distance));
+            if (distance <= 400f) return Mathf.Lerp(v300, v400, Mathf.InverseLerp(300f, 400f, distance));
+            return v400;
+        }
+    }
+}

--- a/Patches/ScopeLifecycle.cs
+++ b/Patches/ScopeLifecycle.cs
@@ -402,6 +402,10 @@ namespace PiPDisabler
             // Per-frame weapon scale compensation (tracks animated FOV transitions)
             Patches.WeaponScalingPatch.UpdateScale();
 
+            // Distance-based LOD bias (raycast + QualitySettings update)
+            DistanceLodBiasController.Tick();
+            CameraSettingsManager.UpdateDistanceLodBias();
+
             // Zeroing input polling
             ZeroingController.Tick();
         }
@@ -771,6 +775,7 @@ namespace PiPDisabler
             ReticleRenderer.Cleanup();
             ScopeEffectsRenderer.Cleanup();
             LensTransparency.RestoreAll();
+            DistanceLodBiasController.Reset();
             CameraSettingsManager.Restore();
             PiPDisabler.RestoreAllCameras();
 
@@ -901,6 +906,7 @@ namespace PiPDisabler
             LensTransparency.RestoreAll();
 
             // 5. Restore camera LOD/culling settings
+            DistanceLodBiasController.Reset();
             CameraSettingsManager.Restore();
 
             // 6. Restore meshes

--- a/PiPDisablerPlugin.cs
+++ b/PiPDisablerPlugin.cs
@@ -218,6 +218,15 @@ namespace PiPDisabler
         internal static ConfigEntry<float> ManualCullingMultiplier;
         internal static Dictionary<string, ConfigEntry<float>> MapManualLodBias;
 
+        // --- Distance-based LOD bias ---
+        internal static ConfigEntry<bool> EnableDistanceLodBias;
+        internal static ConfigEntry<float> DistanceLodBias_50m;
+        internal static ConfigEntry<float> DistanceLodBias_100m;
+        internal static ConfigEntry<float> DistanceLodBias_200m;
+        internal static ConfigEntry<float> DistanceLodBias_300m;
+        internal static ConfigEntry<float> DistanceLodBias_400m;
+        internal static ConfigEntry<int> DistanceLodBiasRaycastMask;
+
         // --- 4. Zeroing ---
         internal static ConfigEntry<bool> EnableZeroing;
         internal static ConfigEntry<KeyCode> ZeroingUpKey;
@@ -377,6 +386,50 @@ namespace PiPDisabler
                     ">0 = force this multiplier (e.g. 2.0 doubles cull distances).",
                     new AcceptableValueRange<float>(0f, 20f),
                     new ConfigurationManagerAttributes { IsAdvanced = true }));
+
+            // --- Distance-based LOD bias ---
+            EnableDistanceLodBias = Config.Bind("Optimization", "EnableDistanceLodBias", false,
+                new ConfigDescription(
+                    "Enable distance-based LOD bias adjustment.\n" +
+                    "Raycasts from the camera each frame while scoped and interpolates LOD bias\n" +
+                    "based on the distance to the aimed-at surface.\n" +
+                    "When enabled, overrides ManualLodBias / per-map LOD bias.",
+                    null,
+                    new ConfigurationManagerAttributes { IsAdvanced = false }));
+            DistanceLodBias_50m = Config.Bind("Optimization", "DistanceLodBias_50m", 6.0f,
+                new ConfigDescription(
+                    "LOD bias at 50 m or closer.",
+                    new AcceptableValueRange<float>(0.1f, 30f),
+                    new ConfigurationManagerAttributes { IsAdvanced = false }));
+            DistanceLodBias_100m = Config.Bind("Optimization", "DistanceLodBias_100m", 5.0f,
+                new ConfigDescription(
+                    "LOD bias at 100 m.",
+                    new AcceptableValueRange<float>(0.1f, 30f),
+                    new ConfigurationManagerAttributes { IsAdvanced = false }));
+            DistanceLodBias_200m = Config.Bind("Optimization", "DistanceLodBias_200m", 4.0f,
+                new ConfigDescription(
+                    "LOD bias at 200 m.",
+                    new AcceptableValueRange<float>(0.1f, 30f),
+                    new ConfigurationManagerAttributes { IsAdvanced = false }));
+            DistanceLodBias_300m = Config.Bind("Optimization", "DistanceLodBias_300m", 3.0f,
+                new ConfigDescription(
+                    "LOD bias at 300 m.",
+                    new AcceptableValueRange<float>(0.1f, 30f),
+                    new ConfigurationManagerAttributes { IsAdvanced = false }));
+            DistanceLodBias_400m = Config.Bind("Optimization", "DistanceLodBias_400m", 2.0f,
+                new ConfigDescription(
+                    "LOD bias at 400 m (and beyond).",
+                    new AcceptableValueRange<float>(0.1f, 30f),
+                    new ConfigurationManagerAttributes { IsAdvanced = false }));
+            DistanceLodBiasRaycastMask = Config.Bind("Optimization", "DistanceLodBiasRaycastMask", -5,
+                new ConfigDescription(
+                    "Physics layer mask for the distance raycast.\n" +
+                    "Negative values are treated as ~(abs(value)), i.e. 'everything except these layers'.\n" +
+                    "-5 = everything except layer 2 (IgnoreRaycast) and layer 0 bit pattern quirk.\n" +
+                    "0 = default (all layers).",
+                    null,
+                    new ConfigurationManagerAttributes { IsAdvanced = true }));
+
             MapManualLodBias = new Dictionary<string, ConfigEntry<float>>(StringComparer.OrdinalIgnoreCase);
 
             BindPerMapLodBias("Woods", "Woods", "Woods");


### PR DESCRIPTION
## Summary
Implements a distance-based LOD bias system that dynamically adjusts model detail levels based on what the player is aiming at through a scope. This improves performance by reducing detail on distant targets while maintaining quality on close-range targets.

## Key Changes
- **New `DistanceLodBiasController` class**: Raycasts from the aiming camera each frame while scoped and remaps hit distance to LOD bias using a piecewise-linear curve with five configurable breakpoints (50m, 100m, 200m, 300m, 400m)
  - Caches raycast results and computed LOD bias for per-frame access
  - Supports configurable physics layer mask for raycast filtering (with negative value convention for layer exclusion)
  - Falls back to 400m bias value when raycast misses (sky/beyond max range)

- **Configuration entries in `PiPDisablerPlugin`**: Added six new config options
  - `EnableDistanceLodBias`: Master toggle for the feature
  - `DistanceLodBias_50m` through `DistanceLodBias_400m`: LOD bias values at each distance breakpoint
  - `DistanceLodBiasRaycastMask`: Physics layer mask control

- **Integration in `CameraSettingsManager`**: New `UpdateDistanceLodBias()` method that applies the computed LOD bias to `QualitySettings.lodBias` each frame while preserving other camera settings

- **Integration in `ScopeLifecycle`**: 
  - Calls `DistanceLodBiasController.Tick()` and `CameraSettingsManager.UpdateDistanceLodBias()` during scope tick
  - Calls `DistanceLodBiasController.Reset()` when exiting scope to clear cached state

## Implementation Details
- Uses piecewise-linear interpolation between breakpoints for smooth LOD transitions
- Distances ≤50m clamp to the 50m value; distances ≥400m clamp to the 400m value
- When enabled, overrides manual LOD bias and per-map LOD bias settings
- Raycast ignores trigger colliders and respects configurable layer masks
- Default configuration: bias decreases from 6.0 at 50m to 2.0 at 400m+

https://claude.ai/code/session_013ptjyf7zriyjBxhkmzCVWL