### PR TITLE
Preserve scoped FOV on pose updates

### DIFF
--- a/Patches/FreelookTracker.cs
+++ b/Patches/FreelookTracker.cs
@@ -62,6 +62,15 @@ namespace PiPDisabler
         }
 
         /// <summary>
+        /// Returns the last scoped FOV written by the mod.
+        /// </summary>
+        public static bool TryGetCachedScopedFov(out float fov)
+        {
+            fov = _lastAppliedScopedFov;
+            return fov > 0.5f;
+        }
+
+        /// <summary>
         /// Called once from plugin Awake to cache the reflection accessor.
         /// </summary>
         public static void Init()

--- a/Patches/PWAMethod23Patch.cs
+++ b/Patches/PWAMethod23Patch.cs
@@ -71,7 +71,9 @@ namespace PiPDisabler.Patches
                 if (isOptic)
                 {
                     float zoomBaseFov = FovController.ZoomBaselineFov;
-                    float zoomedFov = FovController.ComputeZoomedFov();
+                    float zoomedFov;
+                    if (!FreelookTracker.TryGetCachedScopedFov(out zoomedFov))
+                        zoomedFov = FovController.ComputeZoomedFov();
 
                     if (zoomedFov >= 0.5f && zoomedFov < zoomBaseFov)
                     {


### PR DESCRIPTION
### Motivation

- Crouch/pose changes cause the game's pose pipeline to re-run `ProceduralWeaponAnimation.method_23`, which re-invokes `CameraClass.SetFov(...)` and can overwrite the mod's currently applied scoped FOV; this change aims to preserve the mod's cached scoped FOV during those pose-triggered re-applies.

### Description

- Add `FreelookTracker.TryGetCachedScopedFov(out float)` to expose the last scoped FOV the mod successfully applied.
- Update the `ProceduralWeaponAnimation.method_23` interceptor (`PWAMethod23Patch.SetFovWithOverride`) to prefer the cached scoped FOV from `FreelookTracker` and only call `FovController.ComputeZoomedFov()` when no cached value is available.
- Keeps existing behavior of caching via `FreelookTracker.CacheAppliedFov(...)` and preserves original `SetFov` duration/force semantics when substituting FOV.

### Testing

- `git diff -- Patches/FreelookTracker.cs Patches/PWAMethod23Patch.cs` was run to verify the code delta and succeeded.
- `dotnet build PiPDisabler.csproj` was attempted but failed in this environment because `dotnet` is not installed, so no binary build verification was performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba8c6c5c948328b2a1edaf5acedb44)