### PR TITLE
Prevent reticle flash on iron-sight switch

### DIFF
--- a/Patches/ScopeLifecycle.cs
+++ b/Patches/ScopeLifecycle.cs
@@ -165,6 +165,8 @@ namespace PiPDisabler
         /// </summary>
         public static void OnOpticEnabled(OpticSight os)
         {
+            bool currentlyAimingThroughOptic = IsCurrentlyAimingThroughOptic();
+
             if (os != null)
                 _lastEnabledOptic = os;
 
@@ -192,61 +194,70 @@ namespace PiPDisabler
             // would falsely trigger a restore+recut cycle and cause a 1-2 frame mesh flash.
             if (_isScoped && os != null && os != _activeOptic)
             {
-                PiPDisablerPlugin.LogInfo(
-                    $"[ScopeLifecycle] Mode switch while scoped: " +
-                    $"'{(_activeOptic != null ? _activeOptic.name : "?")}'[{FovController.GetOpticTemplateId(_activeOptic)}] → " +
-                    $"'{os.name}'[{FovController.GetOpticTemplateId(os)}]");
-
-                // Update the active optic to the new mode
-                _activeOptic = os;
-
-                float minFov = ZoomController.GetMinFov(os);
-                bool bypassForMode = ShouldBypassForCurrentOptic(os, minFov);
-                if (bypassForMode)
+                if (!currentlyAimingThroughOptic)
                 {
-                    _modBypassedForCurrentScope = true;
-                    ApplyBypassState(os, minFov, reason: "mode switch", restoreFov: true);
-                    return;
+                    PiPDisablerPlugin.LogInfo(
+                        $"[ScopeLifecycle] Ignoring optic enable during non-optic transition: " +
+                        $"'{os.name}'[{FovController.GetOpticTemplateId(os)}]");
                 }
-
-                _modBypassedForCurrentScope = false;
-
-                // Re-extract reticle from the NEW mode's linza
-                ReticleRenderer.Cleanup();
-                ReticleRenderer.ExtractReticle(os);
-
-                // Re-hide lenses (the new mode's lens might not be hidden yet)
-                LensTransparency.HideAllLensSurfaces(os);
-
-                // Recollect housing + weapon renderers for the new mode's geometry.
-                ReticleRenderer.SetHousingRenderers(CollectStencilRenderers(os));
-
-                // Notify FOV controller the mode changed so it re-reads ScopeCameraData
-                FovController.OnModeSwitch();
-
-                // RESTORE all meshes first, then re-cut with new mode's plane position.
-                if (PiPDisablerPlugin.EnableMeshSurgery.Value)
+                else
                 {
-                    MeshSurgeryManager.RestoreForScope(os.transform);
-                    MeshSurgeryManager.ApplyForOptic(os);
-                }
+                    PiPDisablerPlugin.LogInfo(
+                        $"[ScopeLifecycle] Mode switch while scoped: " +
+                        $"'{(_activeOptic != null ? _activeOptic.name : "?")}'[{FovController.GetOpticTemplateId(_activeOptic)}] → " +
+                        $"'{os.name}'[{FovController.GetOpticTemplateId(os)}]");
 
-                // Re-apply camera settings for the new mode's FOV
-                CameraSettingsManager.ApplyForOptic(os);
+                    // Update the active optic to the new mode
+                    _activeOptic = os;
 
-                // Capture weapon base scale/FOV before FOV changes
-                Patches.WeaponScalingPatch.CaptureBaseState();
+                    float minFov = ZoomController.GetMinFov(os);
+                    bool bypassForMode = ShouldBypassForCurrentOptic(os, minFov);
+                    if (bypassForMode)
+                    {
+                        _modBypassedForCurrentScope = true;
+                        ApplyBypassState(os, minFov, reason: "mode switch", restoreFov: true);
+                        return;
+                    }
 
-                // If freelooking, defer reticle/effects/FOV — they'll be restored
-                // when freelook ends via FreelookTracker.OnFreelookExit().
-                if (!FreelookTracker.IsFreelooking)
-                {
-                    // Show reticle for the new mode (with magnification scaling)
-                    float modeMag = ZoomController.GetMagnification(os);
-                    ReticleRenderer.Show(os, modeMag);
+                    _modBypassedForCurrentScope = false;
 
-                    // Animated FOV change for mode switch (uses configured duration)
-                    ApplyFov(true);
+                    // Re-extract reticle from the NEW mode's linza
+                    ReticleRenderer.Cleanup();
+                    ReticleRenderer.ExtractReticle(os);
+
+                    // Re-hide lenses (the new mode's lens might not be hidden yet)
+                    LensTransparency.HideAllLensSurfaces(os);
+
+                    // Recollect housing + weapon renderers for the new mode's geometry.
+                    ReticleRenderer.SetHousingRenderers(CollectStencilRenderers(os));
+
+                    // Notify FOV controller the mode changed so it re-reads ScopeCameraData
+                    FovController.OnModeSwitch();
+
+                    // RESTORE all meshes first, then re-cut with new mode's plane position.
+                    if (PiPDisablerPlugin.EnableMeshSurgery.Value)
+                    {
+                        MeshSurgeryManager.RestoreForScope(os.transform);
+                        MeshSurgeryManager.ApplyForOptic(os);
+                    }
+
+                    // Re-apply camera settings for the new mode's FOV
+                    CameraSettingsManager.ApplyForOptic(os);
+
+                    // Capture weapon base scale/FOV before FOV changes
+                    Patches.WeaponScalingPatch.CaptureBaseState();
+
+                    // If freelooking, defer reticle/effects/FOV — they'll be restored
+                    // when freelook ends via FreelookTracker.OnFreelookExit().
+                    if (!FreelookTracker.IsFreelooking)
+                    {
+                        // Show reticle for the new mode (with magnification scaling)
+                        float modeMag = ZoomController.GetMagnification(os);
+                        ReticleRenderer.Show(os, modeMag);
+
+                        // Animated FOV change for mode switch (uses configured duration)
+                        ApplyFov(true);
+                    }
                 }
             }
 
@@ -261,6 +272,28 @@ namespace PiPDisabler
             ReticleRenderer.Hide();
             ScopeEffectsRenderer.Hide();
             CheckAndUpdate("OnOpticDisabled");
+        }
+
+        private static bool IsCurrentlyAimingThroughOptic()
+        {
+            if (!_reflectionReady) return false;
+
+            try
+            {
+                var player = GetLocalPlayer();
+                var pwa = player?.ProceduralWeaponAnimation;
+                if (pwa == null) return false;
+                if (!_getIsAiming(pwa)) return false;
+
+                object currentScope = _getCurrentScope(pwa);
+                if (currentScope == null) return false;
+
+                return _getIsOptic(currentScope);
+            }
+            catch
+            {
+                return false;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
### Motivation
- Prevent transient `OpticSight.OnEnable` events from re-showing the scope reticle when the player is switching to non-optic aiming modes (iron/collimator), which caused a visible reticle flash.
- Ensure mode-switch handling only runs when the player is still actively aiming through an optic to avoid spurious restore/re-cut cycles and mesh/reticle flicker.

### Description
- Added a helper `IsCurrentlyAimingThroughOptic()` that queries the player's `ProceduralWeaponAnimation` via the existing reflection delegates to detect whether the current PWA scope is an optic.
- At the start of `OnOpticEnabled`, compute `currentlyAimingThroughOptic` and gate the existing scoped mode-switch path on that flag.
- When the flag is false, the code now logs and ignores the transient optic-enable event; when true the original re-extract/mesh-surgery/FOV/reticle show flow is unchanged.

### Testing
- Attempted `dotnet build` in the environment but it could not run because `dotnet` is not installed, so no build was produced.
- Checked for C# toolchain with `command -v csc || command -v mcs || command -v msbuild || command -v xbuild` and found no available compiler tools.
- No automated unit tests or builds were executed due to the missing toolchain.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba909aca7c8328a9ae0d462e30740e)