### PR TITLE
Preserve scoped FOV on pose updates

### DIFF
--- a/Patches/PWAMethod23Patch.cs
+++ b/Patches/PWAMethod23Patch.cs
@@ -5,6 +5,7 @@ using EFT.Animations;
 using EFT.CameraControl;
 using HarmonyLib;
 using SPT.Reflection.Patching;
+using UnityEngine;
 
 namespace PiPDisabler.Patches
 {
@@ -71,13 +72,21 @@ namespace PiPDisabler.Patches
                 if (isOptic)
                 {
                     float zoomBaseFov = FovController.ZoomBaselineFov;
-                    float zoomedFov = FovController.ComputeZoomedFov();
+                    float desiredFov = FovController.ComputeZoomedFov();
 
-                    if (zoomedFov >= 0.5f && zoomedFov < zoomBaseFov)
+                    if (desiredFov >= 0.5f)
                     {
-                        targetFov = zoomedFov;
-                        FreelookTracker.CacheAppliedFov(zoomedFov);
-                        // Keep the game's original duration so ADS/unADS speed is unaffected
+                        if (desiredFov > zoomBaseFov)
+                            desiredFov = zoomBaseFov;
+
+                        if (Mathf.Abs(targetFov - desiredFov) > 0.01f)
+                        {
+                            PiPDisablerPlugin.LogInfo(
+                                $"[PWAMethod23Patch] Overriding method_23 FOV {targetFov:F1}° → {desiredFov:F1}°");
+                        }
+
+                        targetFov = desiredFov;
+                        FreelookTracker.CacheAppliedFov(desiredFov);
                         force = false;
                     }
                 }


### PR DESCRIPTION
### Motivation
- Fix crouch/pose-driven FOV resets where a pose update reruns `ProceduralWeaponAnimation.method_23` and overwrites a mod-applied scoped FOV (especially noticeable for 1x modes). 

### Description
- Update `PWAMethod23Patch` to compute `desiredFov = FovController.ComputeZoomedFov()` and apply it whenever valid instead of only when the computed value is below the baseline. 
- Clamp the computed `desiredFov` to the mod baseline (`ZoomBaselineFov`) and replace the incoming `targetFov` when it meaningfully differs, while caching the applied value via `FreelookTracker.CacheAppliedFov`. 
- Add a focused log line when the patch overrides `method_23` FOV and include `using UnityEngine;` for `Mathf` usage. 

### Testing
- Attempted to build with `dotnet build PiPDisabler.csproj`, but the container lacks `dotnet` so the build could not be run. 
- Verified the local code change with `git diff` showing the adjusted logic in `Patches/PWAMethod23Patch.cs`. 
- Committed the patch with message `Preserve scoped FOV on pose updates` successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba948ccf748328b804c895bc582867)