### PR TITLE
Handle integrated-irons sub-scope transitions (ELCAN)

### DIFF
--- a/Patches/FovController.cs
+++ b/Patches/FovController.cs
@@ -389,6 +389,11 @@ namespace PiPDisabler
         ///     └── mode_0 / mode_1
         ///          └── OpticSight  ← we start here
         /// </summary>
+        internal static object GetSightComponentForOptic(OpticSight os)
+        {
+            return FindSightComponent(os);
+        }
+
         private static object FindSightComponent(OpticSight os)
         {
             // Per-scope cache: SightComponent doesn't change during a scope session

--- a/Patches/LensTransparency.cs
+++ b/Patches/LensTransparency.cs
@@ -134,6 +134,30 @@ namespace PiPDisabler
                 "[LensTransparency] Restored original materials before scope entry");
         }
 
+        public static void ForceBlackLensMaterials(OpticSight os)
+        {
+            if (os == null) return;
+
+            Transform searchRoot = FindScopeSearchRoot(os.transform);
+            var allRenderers = searchRoot.GetComponentsInChildren<Renderer>(true);
+            for (int i = 0; i < allRenderers.Length; i++)
+            {
+                var renderer = allRenderers[i];
+                if (renderer == null) continue;
+                if (!renderer.gameObject.activeInHierarchy) continue;
+                if (!IsLensSurface(renderer) || ShouldSkipForCollimator(renderer)) continue;
+                ApplyBlackMaterial(renderer);
+            }
+
+            try
+            {
+                var lensRenderer = os.LensRenderer;
+                if (lensRenderer != null)
+                    ApplyBlackMaterial(lensRenderer);
+            }
+            catch { }
+        }
+
         /// <summary>
         /// Full cleanup: restores original materials and clears all internal caches.
         /// Call when the mod is disabled or the plugin is destroyed so EFT's native
@@ -251,12 +275,13 @@ namespace PiPDisabler
         /// _trulyOriginalMaterials so the next scope-enter always saves the correct
         /// originals rather than the black placeholder.
         /// </summary>
-        public static void RestoreAll()
+        public static void RestoreAll(bool forceBlackLens = false)
         {
             if (_hidden.Count == 0) return;
 
-            bool blackLens = PiPDisablerPlugin.BlackLensWhenUnscoped != null
-                             && PiPDisablerPlugin.BlackLensWhenUnscoped.Value;
+            bool blackLens = forceBlackLens ||
+                             (PiPDisablerPlugin.BlackLensWhenUnscoped != null &&
+                              PiPDisablerPlugin.BlackLensWhenUnscoped.Value);
 
             for (int i = 0; i < _hidden.Count; i++)
             {

--- a/Patches/PWAMethod23Patch.cs
+++ b/Patches/PWAMethod23Patch.cs
@@ -60,6 +60,7 @@ namespace PiPDisabler.Patches
                 PiPDisablerPlugin.ModEnabled.Value &&
                 PiPDisablerPlugin.EnableZoom.Value &&
                 ScopeLifecycle.IsScoped &&
+                ScopeLifecycle.IsOpticSubScopeActive &&
                 !ScopeLifecycle.IsModBypassedForCurrentScope &&
                 !FreelookTracker.IsFreelooking &&
                 pwa.IsAiming &&

--- a/Patches/Patcher.cs
+++ b/Patches/Patcher.cs
@@ -15,6 +15,8 @@ namespace PiPDisabler.Patches
             SafeEnable<OpticSightOnEnablePatch>();
             SafeEnable<OpticSightOnDisablePatch>();
             SafeEnable<ChangeAimingModePatch>();
+            SafeEnable<ChangeAimingModeIndexedPatch>();
+            SafeEnable<SetAimPatch>();
             // No-PiP
             SafeEnable<PiPDisabler.OpticComponentUpdaterCopyComponentFromOptic_DisablePiP>();
             SafeEnable<PiPDisabler.OpticComponentUpdaterLateUpdate_DisablePiP>();

--- a/Patches/ScopeAimStateResolver.cs
+++ b/Patches/ScopeAimStateResolver.cs
@@ -1,0 +1,374 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using EFT;
+using EFT.CameraControl;
+using EFT.InventoryLogic;
+using UnityEngine;
+
+namespace PiPDisabler
+{
+    internal enum ScopeSubScopeKind
+    {
+        Unknown = 0,
+        Optic = 1,
+        IntegratedIrons = 2,
+    }
+
+    internal sealed class ScopeAimStateSnapshot
+    {
+        public Weapon Weapon;
+        public int GlobalAimIndex;
+        public OpticSight ActiveOptic;
+        public object SightComponent;
+        public int ScopesCount;
+        public int SelectedScopeIndex;
+        public Transform SightRoot;
+        public Transform ActiveAimTransform;
+        public string ActiveAimPath;
+        public List<Transform> LocalAimEntries;
+        public ScopeSubScopeKind Kind;
+        public string ClassificationReason;
+        public string GlobalMappingSummary;
+    }
+
+    internal static class ScopeAimStateResolver
+    {
+        private static Type _sightComponentType;
+        private static bool _sightComponentTypeSearched;
+        private static PropertyInfo _selectedScopeIndexProp;
+        private static PropertyInfo _scopesCountProp;
+        private static PropertyInfo _aimIndexProp;
+
+        internal static ScopeAimStateSnapshot Resolve(OpticSight os)
+        {
+            if (os == null) return null;
+
+            var snapshot = new ScopeAimStateSnapshot
+            {
+                ActiveOptic = os,
+                LocalAimEntries = new List<Transform>(),
+                Kind = ScopeSubScopeKind.Unknown,
+                ClassificationReason = "unresolved",
+                ActiveAimPath = "(none)",
+                GlobalMappingSummary = "(unavailable)"
+            };
+
+            try
+            {
+                snapshot.Weapon = GetCurrentWeapon();
+                snapshot.GlobalAimIndex = GetAimIndex(snapshot.Weapon);
+                snapshot.SightComponent = ResolveSightComponent(os);
+                snapshot.ScopesCount = GetScopesCount(snapshot.SightComponent);
+                snapshot.SelectedScopeIndex = GetSelectedScopeIndex(snapshot.SightComponent, snapshot.ScopesCount);
+                snapshot.SightRoot = ResolveSightRoot(os);
+                snapshot.LocalAimEntries = CollectAimEntries(snapshot.SightRoot);
+
+                if (snapshot.LocalAimEntries.Count > 0 &&
+                    snapshot.SelectedScopeIndex >= 0 &&
+                    snapshot.SelectedScopeIndex < snapshot.LocalAimEntries.Count)
+                {
+                    snapshot.ActiveAimTransform = snapshot.LocalAimEntries[snapshot.SelectedScopeIndex];
+                    snapshot.ActiveAimPath = ScopeHierarchy.GetRelativePath(snapshot.ActiveAimTransform, snapshot.SightRoot);
+                }
+
+                snapshot.Kind = Classify(os, snapshot, out var reason);
+                snapshot.ClassificationReason = reason;
+                snapshot.GlobalMappingSummary = BuildGlobalMappingSummary(snapshot.Weapon, snapshot.SightComponent, snapshot.GlobalAimIndex);
+            }
+            catch (Exception ex)
+            {
+                snapshot.ClassificationReason = $"exception: {ex.Message}";
+            }
+
+            return snapshot;
+        }
+
+        internal static int GetCurrentWeaponAimIndex()
+        {
+            return GetAimIndex(GetCurrentWeapon());
+        }
+
+        private static ScopeSubScopeKind Classify(OpticSight os, ScopeAimStateSnapshot snapshot, out string reason)
+        {
+            var opticTransforms = CollectOpticScopeTransforms(snapshot.SightRoot);
+
+            if (snapshot.ActiveAimTransform != null)
+            {
+                for (int i = 0; i < opticTransforms.Count; i++)
+                {
+                    if (opticTransforms[i] == snapshot.ActiveAimTransform)
+                    {
+                        reason = $"active aim matches optic ScopeTransform '{snapshot.ActiveAimTransform.name}'";
+                        return ScopeSubScopeKind.Optic;
+                    }
+                }
+
+                if (snapshot.LocalAimEntries.Count > 1 && opticTransforms.Count > 0)
+                {
+                    reason = $"active aim '{snapshot.ActiveAimTransform.name}' is outside optic ScopeTransform set";
+                    return ScopeSubScopeKind.IntegratedIrons;
+                }
+            }
+
+            Transform ownScopeTransform = null;
+            try { ownScopeTransform = os.ScopeTransform; } catch { }
+
+            if (ownScopeTransform != null &&
+                snapshot.ActiveAimTransform != null &&
+                ownScopeTransform == snapshot.ActiveAimTransform)
+            {
+                reason = $"active aim matches active OpticSight.ScopeTransform '{ownScopeTransform.name}'";
+                return ScopeSubScopeKind.Optic;
+            }
+
+            if (snapshot.ScopesCount <= 1)
+            {
+                reason = "single-scope sight";
+                return ScopeSubScopeKind.Optic;
+            }
+
+            reason = "no optic/integrated-irons classification match";
+            return ScopeSubScopeKind.Unknown;
+        }
+
+        private static Transform ResolveSightRoot(OpticSight os)
+        {
+            var scopeRoot = ScopeHierarchy.FindScopeRoot(os.transform);
+            if (scopeRoot == null) return os.transform;
+            if (scopeRoot.parent != null) return scopeRoot.parent;
+            return scopeRoot;
+        }
+
+        private static List<Transform> CollectAimEntries(Transform sightRoot)
+        {
+            var result = new List<Transform>();
+            if (sightRoot == null) return result;
+
+            var all = sightRoot.GetComponentsInChildren<Transform>(true);
+            for (int i = 0; i < all.Length; i++)
+            {
+                var t = all[i];
+                if (t == null || t == sightRoot) continue;
+
+                string name = t.name ?? string.Empty;
+                if (name.IndexOf("aim_camera", StringComparison.OrdinalIgnoreCase) < 0) continue;
+
+                result.Add(t);
+            }
+
+            result.Sort(CompareAimTransforms);
+            return result;
+        }
+
+        private static List<Transform> CollectOpticScopeTransforms(Transform sightRoot)
+        {
+            var result = new List<Transform>();
+            if (sightRoot == null) return result;
+
+            var optics = sightRoot.GetComponentsInChildren<OpticSight>(true);
+            for (int i = 0; i < optics.Length; i++)
+            {
+                var optic = optics[i];
+                if (optic == null) continue;
+
+                Transform scopeTransform = null;
+                try { scopeTransform = optic.ScopeTransform; } catch { }
+                if (scopeTransform == null || result.Contains(scopeTransform)) continue;
+
+                result.Add(scopeTransform);
+            }
+
+            return result;
+        }
+
+        private static int CompareAimTransforms(Transform a, Transform b)
+        {
+            int numA = ParseTrailingNumber(a != null ? a.name : null);
+            int numB = ParseTrailingNumber(b != null ? b.name : null);
+            int compare = numA.CompareTo(numB);
+            if (compare != 0) return compare;
+            return string.CompareOrdinal(a != null ? a.name : null, b != null ? b.name : null);
+        }
+
+        private static int ParseTrailingNumber(string value)
+        {
+            if (string.IsNullOrEmpty(value)) return int.MaxValue;
+
+            int end = value.Length - 1;
+            while (end >= 0 && char.IsDigit(value[end])) end--;
+            if (end == value.Length - 1) return int.MaxValue;
+
+            string digits = value.Substring(end + 1);
+            return int.TryParse(digits, out var parsed) ? parsed : int.MaxValue;
+        }
+
+        private static object ResolveSightComponent(OpticSight os)
+        {
+            try { return FovController.GetSightComponentForOptic(os); }
+            catch { return null; }
+        }
+
+        private static int GetSelectedScopeIndex(object sightComponent, int scopesCount)
+        {
+            if (sightComponent == null) return 0;
+
+            try
+            {
+                if (_selectedScopeIndexProp == null)
+                {
+                    _selectedScopeIndexProp = sightComponent.GetType().GetProperty("SelectedScopeIndex",
+                        BindingFlags.Public | BindingFlags.Instance);
+                }
+
+                if (_selectedScopeIndexProp != null)
+                {
+                    int value = (int)_selectedScopeIndexProp.GetValue(sightComponent, null);
+                    if (scopesCount > 0)
+                        value = Mathf.Abs(value) % scopesCount;
+                    return value;
+                }
+            }
+            catch { }
+
+            return 0;
+        }
+
+        private static int GetScopesCount(object sightComponent)
+        {
+            if (sightComponent == null) return 1;
+
+            try
+            {
+                if (_scopesCountProp == null)
+                {
+                    _scopesCountProp = sightComponent.GetType().GetProperty("ScopesCount",
+                        BindingFlags.Public | BindingFlags.Instance);
+                }
+
+                if (_scopesCountProp != null)
+                    return Math.Max(1, (int)_scopesCountProp.GetValue(sightComponent, null));
+            }
+            catch { }
+
+            return 1;
+        }
+
+        private static Weapon GetCurrentWeapon()
+        {
+            var player = PiPDisablerPlugin.GetLocalPlayer();
+            var firearmController = player != null ? player.HandsController as Player.FirearmController : null;
+            return firearmController != null ? firearmController.Item as Weapon : null;
+        }
+
+        private static int GetAimIndex(Weapon weapon)
+        {
+            if (weapon == null) return 0;
+
+            try
+            {
+                if (_aimIndexProp == null)
+                {
+                    _aimIndexProp = typeof(Weapon).GetProperty("AimIndex", BindingFlags.Public | BindingFlags.Instance);
+                }
+
+                if (_aimIndexProp != null)
+                {
+                    object reactive = _aimIndexProp.GetValue(weapon, null);
+                    if (reactive != null)
+                    {
+                        var valueProp = reactive.GetType().GetProperty("Value", BindingFlags.Public | BindingFlags.Instance);
+                        if (valueProp != null)
+                            return (int)valueProp.GetValue(reactive, null);
+                    }
+                }
+            }
+            catch { }
+
+            return 0;
+        }
+
+        private static string BuildGlobalMappingSummary(Weapon weapon, object targetSightComponent, int activeGlobalAimIndex)
+        {
+            if (weapon == null) return "(no weapon)";
+
+            try
+            {
+                var modsProp = weapon.GetType().GetProperty("Mods", BindingFlags.Public | BindingFlags.Instance);
+                var mods = modsProp != null ? modsProp.GetValue(weapon, null) as IEnumerable<Item> : null;
+                if (mods == null) return "(weapon mods unavailable)";
+
+                int globalIndex = 0;
+                var chunks = new List<string>();
+
+                foreach (var mod in mods)
+                {
+                    if (mod == null) continue;
+
+                    var sightComponent = GetSightComponent(mod);
+                    if (sightComponent == null) continue;
+
+                    int count = GetScopesCount(sightComponent);
+                    int end = globalIndex + count - 1;
+                    bool isTarget = ReferenceEquals(sightComponent, targetSightComponent);
+                    string label = mod.Id ?? "sight";
+                    chunks.Add($"{(isTarget ? "*" : string.Empty)}{label}[{globalIndex}-{end}]");
+                    globalIndex += count;
+                }
+
+                if (chunks.Count == 0) return "(no sight mapping)";
+                return $"aimIndex={activeGlobalAimIndex} map={string.Join(", ", chunks)}";
+            }
+            catch (Exception ex)
+            {
+                return $"(mapping failed: {ex.Message})";
+            }
+        }
+
+        private static object GetSightComponent(Item item)
+        {
+            if (item == null) return null;
+
+            try
+            {
+                if (!_sightComponentTypeSearched)
+                {
+                    _sightComponentTypeSearched = true;
+                    foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
+                    {
+                        _sightComponentType = asm.GetType("EFT.InventoryLogic.SightComponent");
+                        if (_sightComponentType != null) break;
+                    }
+
+                    if (_sightComponentType == null)
+                    {
+                        foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
+                        {
+                            foreach (var type in asm.GetTypes())
+                            {
+                                if (type.Name == "SightComponent")
+                                {
+                                    _sightComponentType = type;
+                                    break;
+                                }
+                            }
+
+                            if (_sightComponentType != null) break;
+                        }
+                    }
+                }
+
+                if (_sightComponentType == null) return null;
+
+                var method = item.GetType().GetMethod("GetItemComponent", BindingFlags.Public | BindingFlags.Instance);
+                if (method == null) return null;
+
+                return method.MakeGenericMethod(_sightComponentType).Invoke(item, null);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/Patches/ScopeDetectionPatches.cs
+++ b/Patches/ScopeDetectionPatches.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Reflection;
 using EFT;
 using EFT.CameraControl;
@@ -45,16 +46,69 @@ namespace PiPDisabler.Patches
     internal sealed class ChangeAimingModePatch : ModulePatch
     {
         protected override MethodBase GetTargetMethod()
-            => AccessTools.Method(typeof(Player.FirearmController), "ChangeAimingMode");
+            => AccessTools.Method(typeof(Player.FirearmController), "ChangeAimingMode", Type.EmptyTypes);
+
+        [PatchPrefix]
+        private static void Prefix(ref int __state)
+        {
+            if (!PiPDisablerPlugin.ModEnabled.Value) return;
+            __state = ScopeAimStateResolver.GetCurrentWeaponAimIndex();
+        }
 
         [PatchPostfix]
-        private static void Postfix()
+        private static void Postfix(int __state)
         {
             if (!PiPDisablerPlugin.ModEnabled.Value) return;
 
             PiPDisablerPlugin.LogInfo(
                 $"[Patch] ChangeAimingMode frame={Time.frameCount}");
-            ScopeLifecycle.CheckAndUpdate("ChangeAimingMode");
+            ScopeLifecycle.OnAimModeChanged("ChangeAimingMode()", __state);
+        }
+    }
+
+    internal sealed class ChangeAimingModeIndexedPatch : ModulePatch
+    {
+        protected override MethodBase GetTargetMethod()
+            => AccessTools.Method(typeof(Player.FirearmController), "ChangeAimingMode", new[] { typeof(int) });
+
+        [PatchPrefix]
+        private static void Prefix(ref int __state)
+        {
+            if (!PiPDisablerPlugin.ModEnabled.Value) return;
+            __state = ScopeAimStateResolver.GetCurrentWeaponAimIndex();
+        }
+
+        [PatchPostfix]
+        private static void Postfix(int modeIndex, int __state)
+        {
+            if (!PiPDisablerPlugin.ModEnabled.Value) return;
+
+            PiPDisablerPlugin.LogInfo(
+                $"[Patch] ChangeAimingMode({modeIndex}) frame={Time.frameCount}");
+            ScopeLifecycle.OnAimModeChanged($"ChangeAimingMode({modeIndex})", __state);
+        }
+    }
+
+    internal sealed class SetAimPatch : ModulePatch
+    {
+        protected override MethodBase GetTargetMethod()
+            => AccessTools.Method(typeof(Player.FirearmController), "SetAim", new[] { typeof(int) });
+
+        [PatchPrefix]
+        private static void Prefix(ref int __state)
+        {
+            if (!PiPDisablerPlugin.ModEnabled.Value) return;
+            __state = ScopeAimStateResolver.GetCurrentWeaponAimIndex();
+        }
+
+        [PatchPostfix]
+        private static void Postfix(int scopeIndex, int __state)
+        {
+            if (!PiPDisablerPlugin.ModEnabled.Value) return;
+
+            PiPDisablerPlugin.LogInfo(
+                $"[Patch] SetAim({scopeIndex}) frame={Time.frameCount}");
+            ScopeLifecycle.OnAimModeChanged($"SetAim({scopeIndex})", __state);
         }
     }
 }

--- a/Patches/ScopeLifecycle.cs
+++ b/Patches/ScopeLifecycle.cs
@@ -42,6 +42,7 @@ namespace PiPDisabler
         private static OpticSight _activeOptic;
         private static OpticSight _lastEnabledOptic; // cache from OnEnable
         private static bool _modBypassedForCurrentScope;
+        private static ScopeSubScopeKind _activeSubScopeKind = ScopeSubScopeKind.Unknown;
 
         // Thermal/NV discovery cache (ScopeData component shape is stable at runtime)
         private static Type _scopeDataType;
@@ -58,6 +59,7 @@ namespace PiPDisabler
         public static bool IsScoped => _isScoped;
         public static bool IsModBypassedForCurrentScope => _modBypassedForCurrentScope;
         public static OpticSight ActiveOptic => _activeOptic;
+        internal static bool IsOpticSubScopeActive => _activeSubScopeKind != ScopeSubScopeKind.IntegratedIrons;
 
         /// <summary>
         /// Shared optic classification helper for other systems that must make
@@ -215,38 +217,14 @@ namespace PiPDisabler
                 ReticleRenderer.Cleanup();
                 ReticleRenderer.ExtractReticle(os);
 
-                // Re-hide lenses (the new mode's lens might not be hidden yet)
-                LensTransparency.HideAllLensSurfaces(os);
-
-                // Recollect housing + weapon renderers for the new mode's geometry.
-                ReticleRenderer.SetHousingRenderers(CollectStencilRenderers(os));
-
                 // Notify FOV controller the mode changed so it re-reads ScopeCameraData
                 FovController.OnModeSwitch();
-
-                // RESTORE all meshes first, then re-cut with new mode's plane position.
-                if (PiPDisablerPlugin.EnableMeshSurgery.Value)
-                {
-                    MeshSurgeryManager.RestoreForScope(os.transform);
-                    MeshSurgeryManager.ApplyForOptic(os);
-                }
-
-                // Re-apply camera settings for the new mode's FOV
-                CameraSettingsManager.ApplyForOptic(os);
-
-                // Capture weapon base scale/FOV before FOV changes
-                Patches.WeaponScalingPatch.CaptureBaseState();
 
                 // If freelooking, defer reticle/effects/FOV — they'll be restored
                 // when freelook ends via FreelookTracker.OnFreelookExit().
                 if (!FreelookTracker.IsFreelooking)
                 {
-                    // Show reticle for the new mode (with magnification scaling)
-                    float modeMag = ZoomController.GetMagnification(os);
-                    ReticleRenderer.Show(os, modeMag);
-
-                    // Animated FOV change for mode switch (uses configured duration)
-                    ApplyFov(true);
+                    ApplyCurrentSubScopeVisualState(force: true, reason: "mode switch", animateFov: true);
                 }
             }
 
@@ -383,19 +361,21 @@ namespace PiPDisabler
                 // FOV restore is handled by the PlayerLookPatch transpiler which
                 // intercepts Player.Look's SetFov(35) and substitutes our cached FOV.
                 // Re-hide lenses in case EFT restored them during freelook.
-                LensTransparency.EnsureHidden();
+                ApplyCurrentSubScopeVisualState(force: true, reason: "freelook exit", animateFov: false);
             }
 
-            // Keep lens hidden (re-kill if EFT restores geometry)
-            LensTransparency.EnsureHidden();
+            if (_activeSubScopeKind != ScopeSubScopeKind.IntegratedIrons)
+                LensTransparency.EnsureHidden();
 
             // Update reticle position/rotation/scale and effects
-            if (_activeOptic != null)
+            if (_activeOptic != null && _activeSubScopeKind != ScopeSubScopeKind.IntegratedIrons)
             {
                 float mag = ZoomController.GetMagnification(_activeOptic);
                 ReticleRenderer.UpdateTransform(mag);
                 ScopeEffectsRenderer.UpdateTransform();
             }
+
+            ApplyCurrentSubScopeVisualState(force: false, reason: "tick", animateFov: false);
 
             // PiP stays disabled via Harmony patches — no per-frame action needed.
 
@@ -416,6 +396,7 @@ namespace PiPDisabler
             if (_isScoped)
                 DoScopeExit();
             _modBypassedForCurrentScope = false;
+            _activeSubScopeKind = ScopeSubScopeKind.Unknown;
             // Always clear the last-enabled cache so a stale OpticSight reference
             // from before the disable doesn't get used on the next scope enter.
             _lastEnabledOptic = null;
@@ -800,6 +781,7 @@ namespace PiPDisabler
 
             _isScoped = true;
             _activeOptic = os;
+            _activeSubScopeKind = ScopeSubScopeKind.Unknown;
             PerScopeMeshSurgerySettings.SetActiveScope(ResolveWhitelistScopeKey(os));
 
             float minFov = ZoomController.GetMinFov(os);
@@ -820,41 +802,7 @@ namespace PiPDisabler
             // 2. Extract reticle texture BEFORE destroying lens mesh
             ReticleRenderer.ExtractReticle(os);
 
-            // 3. Hide ALL lens surfaces in the scope hierarchy (once)
-            LensTransparency.HideAllLensSurfaces(os);
-
-            // 2b. Collect housing + weapon renderers for reticle stencil mask (lens surfaces
-            //     are already empty-meshed above, so they won't end up in the list).
-            ReticleRenderer.SetHousingRenderers(CollectStencilRenderers(os));
-
-            // 3. Get magnification for reticle scaling and zoom
-            float mag = ZoomController.GetMagnification(os);
-
-            // 4. Show reticle overlay at the lens position, scaled for magnification
-            ReticleRenderer.Show(os, mag);
-
-            // 4b. Show lens vignette + scope shadow effects
-            ScopeEffectsRenderer.Show();
-
-            // 5. Mesh surgery (once)
-            if (PiPDisablerPlugin.EnableMeshSurgery.Value)
-                MeshSurgeryManager.ApplyForOptic(os);
-
-            // 6. Show cut plane visualizer (even without mesh surgery, for debugging)
-            if (PiPDisablerPlugin.GetShowCutPlane()
-                && !PiPDisablerPlugin.EnableMeshSurgery.Value)
-            {
-                ShowPlaneOnly(os);
-            }
-
-            // 7. Swap main camera LOD/culling settings with scope camera settings
-            CameraSettingsManager.ApplyForOptic(os);
-
-            // 8. Capture weapon base scale/FOV BEFORE changing FOV (for weapon scaling compensation)
-            Patches.WeaponScalingPatch.CaptureBaseState();
-
-            // 9. Apply animated FOV zoom (uses FovAnimationDuration)
-            ApplyFov(true);
+            ApplyCurrentSubScopeVisualState(force: true, reason: "scope enter", animateFov: true);
 
             // 10. Read initial zeroing distance
             ZeroingController.ReadCurrentZeroing();
@@ -874,6 +822,7 @@ namespace PiPDisabler
 
             _isScoped = false;
             _activeOptic = null;
+            _activeSubScopeKind = ScopeSubScopeKind.Unknown;
             PerScopeMeshSurgerySettings.ClearActiveScope();
 
             // If this scope was bypassed, skip mod cleanup paths.
@@ -944,6 +893,87 @@ namespace PiPDisabler
                 housing.AddRange(LensTransparency.CollectWeaponRenderers(os, housing));
             }
             return housing;
+        }
+
+        internal static void OnAimModeChanged(string source, int beforeAimIndex)
+        {
+            int afterAimIndex = ScopeAimStateResolver.GetCurrentWeaponAimIndex();
+            PiPDisablerPlugin.LogVerbose(
+                $"[ScopeLifecycle] AimIndex change via {source}: before={beforeAimIndex} after={afterAimIndex}");
+
+            CheckAndUpdate(source);
+
+            if (_isScoped && !_modBypassedForCurrentScope && !FreelookTracker.IsFreelooking)
+                ApplyCurrentSubScopeVisualState(force: false, reason: source, animateFov: false);
+        }
+
+        private static void ApplyCurrentSubScopeVisualState(bool force, string reason, bool animateFov)
+        {
+            if (!_isScoped || _modBypassedForCurrentScope) return;
+            if (_activeOptic == null) return;
+
+            var snapshot = ScopeAimStateResolver.Resolve(_activeOptic);
+            if (snapshot == null) return;
+
+            PiPDisablerPlugin.LogVerbose(
+                $"[ScopeLifecycle] Sub-scope check ({reason}): " +
+                $"activeOptic='{_activeOptic.name}' aimIndex={snapshot.GlobalAimIndex} " +
+                $"sightComponent={(snapshot.SightComponent != null ? snapshot.SightComponent.GetType().Name : "null")} " +
+                $"scopes={snapshot.ScopesCount} selected={snapshot.SelectedScopeIndex} " +
+                $"activeAim='{(snapshot.ActiveAimTransform != null ? snapshot.ActiveAimTransform.name : "null")}' " +
+                $"path='{snapshot.ActiveAimPath}' kind={snapshot.Kind} reason='{snapshot.ClassificationReason}' " +
+                $"{snapshot.GlobalMappingSummary}");
+
+            if (!force && snapshot.Kind == _activeSubScopeKind)
+                return;
+
+            if (snapshot.Kind == ScopeSubScopeKind.IntegratedIrons)
+            {
+                PiPDisablerPlugin.LogVerbose("[ScopeLifecycle] restoring original scope mesh");
+                if (PiPDisablerPlugin.GetRestoreOnUnscope())
+                    MeshSurgeryManager.RestoreForScope(_activeOptic.transform);
+
+                PiPDisablerPlugin.LogVerbose("[ScopeLifecycle] forcing lens opaque black");
+                LensTransparency.RestoreAll(forceBlackLens: true);
+                LensTransparency.ForceBlackLensMaterials(_activeOptic);
+
+                PiPDisablerPlugin.LogVerbose("[ScopeLifecycle] hiding reticle due to integrated-irons sub-scope");
+                ReticleRenderer.Hide();
+                ScopeEffectsRenderer.Hide();
+                CameraSettingsManager.Restore();
+                RestoreFov();
+                Patches.WeaponScalingPatch.RestoreScale();
+                PlaneVisualizer.Hide();
+            }
+            else
+            {
+                PiPDisablerPlugin.LogVerbose("[ScopeLifecycle] re-applying optic mesh state");
+                LensTransparency.RestoreBlackLensMaterials();
+                LensTransparency.HideAllLensSurfaces(_activeOptic);
+                ReticleRenderer.SetHousingRenderers(CollectStencilRenderers(_activeOptic));
+
+                if (PiPDisablerPlugin.EnableMeshSurgery.Value)
+                {
+                    MeshSurgeryManager.RestoreForScope(_activeOptic.transform);
+                    MeshSurgeryManager.ApplyForOptic(_activeOptic);
+                }
+                else if (PiPDisablerPlugin.GetShowCutPlane())
+                {
+                    ShowPlaneOnly(_activeOptic);
+                }
+
+                PiPDisablerPlugin.LogVerbose("[ScopeLifecycle] restoring optic lens state");
+                float mag = ZoomController.GetMagnification(_activeOptic);
+                ReticleRenderer.Show(_activeOptic, mag);
+                ScopeEffectsRenderer.Show();
+                CameraSettingsManager.ApplyForOptic(_activeOptic);
+                Patches.WeaponScalingPatch.CaptureBaseState();
+
+                PiPDisablerPlugin.LogVerbose("[ScopeLifecycle] showing reticle due to optic sub-scope");
+                ApplyFov(animateFov);
+            }
+
+            _activeSubScopeKind = snapshot.Kind;
         }
 
         /// <summary>


### PR DESCRIPTION
### Motivation

- Fix incorrect reticle/visual behavior for sights with integrated irons (ELCAN): switching to the irons did not disable the optic component, so prior logic kept reticle/FOV/optic visuals active.  
- Reticle visibility and lens/mesh presentation must follow the active internal aim entry (selected sub-scope) rather than the presence/state of the `OpticSight` component.

### Description

- Add `ScopeAimStateResolver` (`Patches/ScopeAimStateResolver.cs`) that reads the weapon `AimIndex`, resolves the owning `SightComponent`, reads `SelectedScopeIndex`, flattens local `aim_camera` transforms and classifies the active lane as `Optic` or `IntegratedIrons`.  The resolver also builds a human-readable global mapping summary for verbose logs.  
- Move the sub-scope decision point into `ScopeLifecycle.ApplyCurrentSubScopeVisualState(...)` and call it where aim/mode/state changes occur; the method uses `ScopeAimStateResolver.Resolve(...)` and then applies the visual policy for each classification.  The decision and transitions are implemented in `Patches/ScopeLifecycle.cs`.  
- Implement integrated-irons visual behavior: when a sub-scope is classified as `IntegratedIrons` the code restores original meshes, forces lens visuals to opaque black, hides/suppresses the overlay reticle and scope effects, restores camera/FOV/weapon-scaling state, and hides plane visualizer; when returning to the optic lane it restores optic mesh surgery, hides lens geometry, re-extracts and shows the reticle, reapplies camera settings and FOV, and re-captures weapon scale.  
- Add lens helpers to support immediate blackening and restoration: `LensTransparency.ForceBlackLensMaterials(OpticSight)` and `LensTransparency.RestoreAll(bool forceBlackLens)` in `Patches/LensTransparency.cs`.  
- Hook aim-selection change points so sub-scope transitions react immediately: added patches for `SetAim(int)`, `ChangeAimingMode()` and `ChangeAimingMode(int)` in `Patches/ScopeDetectionPatches.cs` and registered them in `Patches/Patcher.cs`.  These patches capture the before/after `AimIndex` for verbose logging and call `ScopeLifecycle.OnAimModeChanged(...)`.  
- Gate the method_23 FOV override (zoom behavior) on the active sub-scope via `ScopeLifecycle.IsOpticSubScopeActive`, preventing optic zoom while the integrated-irons sub-scope is active (`Patches/PWAMethod23Patch.cs`).  
- Expose `FovController.GetSightComponentForOptic(...)` used by the resolver to find the SightComponent for a given `OpticSight` (`Patches/FovController.cs`).  
- Add verbose debug logging (behind existing `VerboseLogging` flag) that emits the AimIndex -> SelectedScopeIndex -> active aim transform -> classification -> decision chain and logs visual transition actions (e.g. "restoring original scope mesh", "forcing lens opaque black", "hiding reticle due to integrated-irons sub-scope", etc.).

Decision location: the sub-scope classification and action are performed at `ScopeLifecycle.ApplyCurrentSubScopeVisualState(...)`, which calls `ScopeAimStateResolver.Resolve(...)` to determine the active lane and then applies the appropriate visual and reticle changes.

Files changed/added (key): `Patches/ScopeAimStateResolver.cs` (new), `Patches/ScopeLifecycle.cs` (changed), `Patches/LensTransparency.cs` (changed), `Patches/ScopeDetectionPatches.cs` (changed), `Patches/PWAMethod23Patch.cs` (changed), `Patches/FovController.cs` (small exposure), `Patches/Patcher.cs` (register patches).

### Testing

- Repository hygiene check (`git diff --cached --check`) completed with no staging errors.  
- Static repo checks (`git status` / diffs) show intended changes and the new file; local commit performed in this environment.  
- Attempted to run `dotnet build PiPDisabler.csproj` but the environment lacks the .NET SDK (`dotnet: command not found`), so full compile verification could not be executed here.  

If you want, I can: run a compile in an environment with the .NET toolchain, or produce a short runbook of steps to test in-game (scenarios: ELCAN main optic -> integrated irons -> back to optic; rapid aim-mode switching; freelook during transitions) and show expected verbose log lines to validate the AimIndex→SelectedScopeIndex→reticle decision chain.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba9e089b788328a6c98e653d27a0fa)