### PR TITLE
Disable lens reticle draw when unscoped (patch OpticRetrice.OnPreCull)

### DIFF
--- a/Patches/LensTransparency.cs
+++ b/Patches/LensTransparency.cs
@@ -6,8 +6,7 @@ using UnityEngine;
 namespace PiPDisabler
 {
     /// <summary>
-    /// Makes scope lens surfaces invisible by REPLACING THEIR MESH with an empty mesh
-    /// AND forcing material properties to transparent as belt-and-suspenders.
+    /// Makes scope lens surfaces invisible by replacing their mesh with an empty mesh.
     ///
     /// Why previous approaches failed:
     ///   - renderer.enabled = false:      EFT re-enables it, or CommandBuffer ignores it
@@ -48,19 +47,6 @@ namespace PiPDisabler
         private static readonly int _propColor = Shader.PropertyToID("_Color");
         private static readonly int _propSwitchToSight = Shader.PropertyToID("_SwitchToSight");
 
-        // Truly original materials per renderer, stored once on first KillMesh call.
-        // Prevents the black material we apply on RestoreAll from being mistaken for
-        // the original if the player scopes in again on the same session.
-        private static readonly Dictionary<int, Material[]> _trulyOriginalMaterials =
-            new Dictionary<int, Material[]>();
-
-        // Renderers that currently have the black material applied (scope not in use).
-        // Tracked so we can restore them before ReticleRenderer reads textures on scope entry,
-        // and so we can fully clean up when the mod is disabled.
-        private static readonly HashSet<Renderer> _blackenedRenderers = new HashSet<Renderer>();
-
-        // Solid black unlit material applied to lens surfaces when unscoped.
-        private static Material _blackLensMaterial;
 
         private static Mesh GetEmptyMesh()
         {
@@ -71,104 +57,13 @@ namespace PiPDisabler
             return _emptyMesh;
         }
 
-        private static Material GetBlackLensMaterial()
-        {
-            if (_blackLensMaterial != null) return _blackLensMaterial;
-            // Unlit/Color: solid color, no lighting, no texture — guaranteed opaque black.
-            // Falls back to Standard if Unlit/Color isn't in the build's shader set.
-            var shader = Shader.Find("Unlit/Color") ?? Shader.Find("Standard");
-            _blackLensMaterial = new Material(shader)
-            {
-                name  = "PiPDisabler_BlackLens",
-                color = Color.black,
-            };
-            return _blackLensMaterial;
-        }
 
         /// <summary>
-        /// Replace all material slots on <paramref name="r"/> with a solid black unlit material.
-        /// Records the renderer in _blackenedRenderers so it can be un-blackened later.
-        /// </summary>
-        private static void ApplyBlackMaterial(Renderer r)
-        {
-            if (r == null) return;
-            try
-            {
-                var blackMat = GetBlackLensMaterial();
-                int slotCount = 1;
-                try { slotCount = r.sharedMaterials.Length; } catch { }
-                if (slotCount < 1) slotCount = 1;
-
-                var blackArray = new Material[slotCount];
-                for (int i = 0; i < slotCount; i++)
-                    blackArray[i] = blackMat;
-
-                r.sharedMaterials = blackArray;
-                _blackenedRenderers.Add(r);
-            }
-            catch { }
-        }
-
-        /// <summary>
-        /// Restores the original sharedMaterials on any lens renderers that currently have
-        /// the black material applied.  Call this at scope ENTRY, before
-        /// ReticleRenderer.ExtractReticle(), so the texture read sees the real OpticSight
-        /// material rather than our Unlit/Color placeholder.
-        /// </summary>
-        public static void RestoreBlackLensMaterials()
-        {
-            if (_blackenedRenderers.Count == 0) return;
-            foreach (var r in _blackenedRenderers)
-            {
-                if (r == null) continue;
-                int rid = r.GetInstanceID();
-                Material[] origMats;
-                if (_trulyOriginalMaterials.TryGetValue(rid, out origMats) && origMats != null)
-                {
-                    try { r.sharedMaterials = origMats; }
-                    catch { }
-                }
-            }
-            _blackenedRenderers.Clear();
-            PiPDisablerPlugin.LogInfo(
-                "[LensTransparency] Restored original materials before scope entry");
-        }
-
-        public static void ForceBlackLensMaterials(OpticSight os)
-        {
-            if (os == null) return;
-
-            Transform searchRoot = FindScopeSearchRoot(os.transform);
-            var allRenderers = searchRoot.GetComponentsInChildren<Renderer>(true);
-            for (int i = 0; i < allRenderers.Length; i++)
-            {
-                var renderer = allRenderers[i];
-                if (renderer == null) continue;
-                if (!renderer.gameObject.activeInHierarchy) continue;
-                if (!IsLensSurface(renderer) || ShouldSkipForCollimator(renderer)) continue;
-                ApplyBlackMaterial(renderer);
-            }
-
-            try
-            {
-                var lensRenderer = os.LensRenderer;
-                if (lensRenderer != null)
-                    ApplyBlackMaterial(lensRenderer);
-            }
-            catch { }
-        }
-
-        /// <summary>
-        /// Full cleanup: restores original materials and clears all internal caches.
-        /// Call when the mod is disabled or the plugin is destroyed so EFT's native
-        /// PiP rendering can use the lens normally.
+        /// Full cleanup for plugin shutdown.
         /// </summary>
         public static void FullRestoreAll()
         {
-            RestoreBlackLensMaterials(); // also clears _blackenedRenderers
-            _trulyOriginalMaterials.Clear();
-            PiPDisablerPlugin.LogInfo(
-                "[LensTransparency] FullRestoreAll: caches cleared");
+            RestoreAll();
         }
 
         /// <summary>
@@ -265,23 +160,11 @@ namespace PiPDisabler
         }
 
         /// <summary>
-        /// Restore all. Called on scope exit.
-        ///
-        /// When BlackLensWhenUnscoped is enabled (default), the lens geometry is
-        /// restored but an opaque black material is applied in place of the original
-        /// PiP/sight material.  This prevents the reticle-flash that occurs during
-        /// the unscope transition and matches the real-world appearance of scope
-        /// glass viewed from outside.  The truly original materials are kept in
-        /// _trulyOriginalMaterials so the next scope-enter always saves the correct
-        /// originals rather than the black placeholder.
+        /// Restore all hidden lens geometry and materials.
         /// </summary>
-        public static void RestoreAll(bool forceBlackLens = false)
+        public static void RestoreAll()
         {
             if (_hidden.Count == 0) return;
-
-            bool blackLens = forceBlackLens ||
-                             (PiPDisablerPlugin.BlackLensWhenUnscoped != null &&
-                              PiPDisablerPlugin.BlackLensWhenUnscoped.Value);
 
             for (int i = 0; i < _hidden.Count; i++)
             {
@@ -307,32 +190,20 @@ namespace PiPDisabler
                         // Re-enable rendering (lens is visible when unscoped).
                         e.Renderer.forceRenderingOff = e.WasForceOff;
 
-                        if (blackLens)
+                        if (e.OriginalMaterials != null)
                         {
-                            // Apply solid black material — no PiP texture, no reticle flash.
-                            ApplyBlackMaterial(e.Renderer);
-                            PiPDisablerPlugin.LogVerbose(
-                                $"[LensTransparency] Applied black lens to '{e.Renderer.gameObject.name}'");
+                            try { e.Renderer.sharedMaterials = e.OriginalMaterials; }
+                            catch { }
                         }
-                        else
-                        {
-                            // Restore original shared materials (legacy path).
-                            if (e.OriginalMaterials != null)
-                            {
-                                try { e.Renderer.sharedMaterials = e.OriginalMaterials; }
-                                catch { }
-                            }
-                            PiPDisablerPlugin.LogVerbose(
-                                $"[LensTransparency] Restored renderer '{e.Renderer.gameObject.name}' forceOff={e.WasForceOff}");
-                        }
+                        PiPDisablerPlugin.LogVerbose(
+                            $"[LensTransparency] Restored renderer '{e.Renderer.gameObject.name}' forceOff={e.WasForceOff}");
                     }
                 }
                 catch { }
             }
 
             PiPDisablerPlugin.LogInfo(
-                $"[LensTransparency] Restored {_hidden.Count} lens meshes" +
-                (blackLens ? " (black lens applied)" : ""));
+                $"[LensTransparency] Restored {_hidden.Count} lens meshes");
             _hidden.Clear();
         }
 
@@ -361,20 +232,8 @@ namespace PiPDisabler
                 mf.sharedMesh = GetEmptyMesh();
             }
 
-            // Save the TRULY ORIGINAL shared materials only on first encounter.
-            // On subsequent scope-ins the renderer may already have the black material
-            // we applied on the previous scope-exit — we must not overwrite the cache.
-            int rid = r.GetInstanceID();
-            if (!_trulyOriginalMaterials.ContainsKey(rid))
-            {
-                Material[] firstSeenMats = null;
-                try { firstSeenMats = r.sharedMaterials; } catch { }
-                if (firstSeenMats != null)
-                    _trulyOriginalMaterials[rid] = firstSeenMats;
-            }
-
             Material[] origMats = null;
-            _trulyOriginalMaterials.TryGetValue(rid, out origMats);
+            try { origMats = r.sharedMaterials; } catch { }
 
             var entry = new HiddenEntry
             {

--- a/Patches/OpticRetriceOnPreCullPatch.cs
+++ b/Patches/OpticRetriceOnPreCullPatch.cs
@@ -1,0 +1,27 @@
+using System.Reflection;
+using HarmonyLib;
+using SPT.Reflection.Patching;
+
+namespace PiPDisabler.Patches
+{
+    internal sealed class OpticRetriceOnPreCullPatch : ModulePatch
+    {
+        protected override MethodBase GetTargetMethod()
+        {
+            var type = AccessTools.TypeByName("EFT.CameraControl.OpticRetrice");
+            return AccessTools.Method(type, "OnPreCull");
+        }
+
+        [PatchPrefix]
+        private static bool Prefix()
+        {
+            if (!PiPDisablerPlugin.ModEnabled.Value)
+                return true;
+
+            if (ScopeLifecycle.IsModBypassedForCurrentScope)
+                return true;
+
+            return ScopeLifecycle.IsScoped && ScopeLifecycle.IsOpticSubScopeActive;
+        }
+    }
+}

--- a/Patches/Patcher.cs
+++ b/Patches/Patcher.cs
@@ -17,6 +17,7 @@ namespace PiPDisabler.Patches
             SafeEnable<ChangeAimingModePatch>();
             SafeEnable<ChangeAimingModeIndexedPatch>();
             SafeEnable<SetAimPatch>();
+            SafeEnable<OpticRetriceOnPreCullPatch>();
             // No-PiP
             SafeEnable<PiPDisabler.OpticComponentUpdaterCopyComponentFromOptic_DisablePiP>();
             SafeEnable<PiPDisabler.OpticComponentUpdaterLateUpdate_DisablePiP>();

--- a/Patches/ScopeLifecycle.cs
+++ b/Patches/ScopeLifecycle.cs
@@ -795,11 +795,7 @@ namespace PiPDisabler
             PiPDisablerPlugin.LogInfo(
                 $"[ScopeLifecycle] ENTER: '{os.name}'[{FovController.GetOpticTemplateId(os)}] frame={Time.frameCount}");
 
-            // 1. Restore any black lens materials so ExtractReticle can read OpticSight textures.
-            //    (RestoreAll on previous scope-exit may have left sharedMaterials as Unlit/Color.)
-            LensTransparency.RestoreBlackLensMaterials();
-
-            // 2. Extract reticle texture BEFORE destroying lens mesh
+            // 1. Extract reticle texture before destroying lens mesh.
             ReticleRenderer.ExtractReticle(os);
 
             ApplyCurrentSubScopeVisualState(force: true, reason: "scope enter", animateFov: true);
@@ -933,9 +929,8 @@ namespace PiPDisabler
                 if (PiPDisablerPlugin.GetRestoreOnUnscope())
                     MeshSurgeryManager.RestoreForScope(_activeOptic.transform);
 
-                PiPDisablerPlugin.LogVerbose("[ScopeLifecycle] forcing lens opaque black");
-                LensTransparency.RestoreAll(forceBlackLens: true);
-                LensTransparency.ForceBlackLensMaterials(_activeOptic);
+                PiPDisablerPlugin.LogVerbose("[ScopeLifecycle] restoring optic lens state");
+                LensTransparency.RestoreAll();
 
                 PiPDisablerPlugin.LogVerbose("[ScopeLifecycle] hiding reticle due to integrated-irons sub-scope");
                 ReticleRenderer.Hide();
@@ -948,7 +943,6 @@ namespace PiPDisabler
             else
             {
                 PiPDisablerPlugin.LogVerbose("[ScopeLifecycle] re-applying optic mesh state");
-                LensTransparency.RestoreBlackLensMaterials();
                 ReticleRenderer.CaptureRearLensMask(_activeOptic);
                 LensTransparency.HideAllLensSurfaces(_activeOptic);
                 ReticleRenderer.SetOccluderRenderers(CollectStencilRenderers(_activeOptic));

--- a/PiPDisablerPlugin.cs
+++ b/PiPDisablerPlugin.cs
@@ -127,7 +127,6 @@ namespace PiPDisabler
         internal static ConfigEntry<KeyCode> DisablePiPToggleKey;
         internal static ConfigEntry<bool> MakeLensesTransparent;
         internal static ConfigEntry<KeyCode> LensesTransparentToggleKey;
-        internal static ConfigEntry<bool> BlackLensWhenUnscoped;
 
         // --- Mesh Surgery ---
         internal static ConfigEntry<bool> EnableMeshSurgery;
@@ -295,13 +294,6 @@ namespace PiPDisabler
             LensesTransparentToggleKey = Config.Bind("General", "LensesTransparentToggleKey", KeyCode.None,
                 new ConfigDescription(
                     "Toggle key for lens transparency.",
-                    null,
-                    new ConfigurationManagerAttributes { IsAdvanced = true }));
-            BlackLensWhenUnscoped = Config.Bind("General", "BlackLensWhenUnscoped", true,
-                new ConfigDescription(
-                    "When unscoping, apply a solid black opaque material to the lens instead of restoring " +
-                "the original PiP/sight material. Eliminates the reticle flash during the unscope " +
-                "transition and gives the scope a realistic dark-glass appearance when not in use.",
                     null,
                     new ConfigurationManagerAttributes { IsAdvanced = true }));
 
@@ -893,7 +885,7 @@ namespace PiPDisabler
             if (!ModEnabled.Value)
             {
                 ScopeLifecycle.ForceExit();
-                LensTransparency.FullRestoreAll(); // restore any lingering black lens materials
+                LensTransparency.FullRestoreAll();
                 PiPDisabler.RestoreAllCameras();
             }
             else


### PR DESCRIPTION
### Motivation
- Prevent the reticle texture from being drawn on the lens when not ADS by stopping the magnified-optic draw at its source (`EFT.CameraControl.OpticRetrice.OnPreCull`) rather than using a black-material workaround that introduced lifecycle complexity. 
- Simplify scope enter/exit handling by restoring original lens meshes/materials normally and remove the extra black-lens material/cache paths.

### Description
- Add a Harmony prefix patch `Patches/OpticRetriceOnPreCullPatch.cs` that targets `EFT.CameraControl.OpticRetrice.OnPreCull` and only allows the original method to run when the mod is scoped on an optic sub-scope (returns `true` only if `ScopeLifecycle.IsScoped && ScopeLifecycle.IsOpticSubScopeActive`, while preserving bypass and mod-disabled behavior). 
- Register the new patch in `Patches.Patcher.Enable()` by calling `SafeEnable<OpticRetriceOnPreCullPatch>()`. 
- Remove the `BlackLensWhenUnscoped` config and related black-material caching/restore code from `LensTransparency` and `PiPDisablerPlugin`, and simplify `LensTransparency.FullRestoreAll()` to call `RestoreAll()`. 
- Adjust scope lifecycle flows in `Patches/ScopeLifecycle.cs` to extract the reticle texture before hiding meshes and to call `LensTransparency.RestoreAll()` on exit / integrated-iron transitions instead of forcing black lens materials or restoring a black placeholder. 

### Testing
- Attempted `dotnet build PiPDisabler.csproj -v minimal`, but the environment does not have `dotnet` installed so compilation could not be run. 
- Verified the change set via code inspection and `rg` searches to confirm the new `OpticRetriceOnPreCullPatch` exists and is registered in `Patcher.Enable()`, and confirmed removal of `BlackLensWhenUnscoped` references. 
- Committed the edits and verified `git status`/commit output showing the five modified files and the new patch file.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69babf1cad4c8328ad883b96a902dcbd)