### PR TITLE
Disable optic lens reticle while unscoped

### DIFF
--- a/Patches/OpticRetricePatch.cs
+++ b/Patches/OpticRetricePatch.cs
@@ -1,0 +1,19 @@
+using System.Reflection;
+using EFT.CameraControl;
+using HarmonyLib;
+using SPT.Reflection.Patching;
+
+namespace PiPDisabler.Patches
+{
+    internal sealed class OpticRetriceOnPreCullPatch : ModulePatch
+    {
+        protected override MethodBase GetTargetMethod()
+            => AccessTools.Method(typeof(OpticRetrice), "OnPreCull");
+
+        [PatchPrefix]
+        private static bool Prefix()
+        {
+            return !PiPDisablerPlugin.ModEnabled.Value || ScopeLifecycle.IsScoped;
+        }
+    }
+}

--- a/Patches/Patcher.cs
+++ b/Patches/Patcher.cs
@@ -17,6 +17,7 @@ namespace PiPDisabler.Patches
             SafeEnable<ChangeAimingModePatch>();
             SafeEnable<ChangeAimingModeIndexedPatch>();
             SafeEnable<SetAimPatch>();
+            SafeEnable<OpticRetriceOnPreCullPatch>();
             // No-PiP
             SafeEnable<PiPDisabler.OpticComponentUpdaterCopyComponentFromOptic_DisablePiP>();
             SafeEnable<PiPDisabler.OpticComponentUpdaterLateUpdate_DisablePiP>();


### PR DESCRIPTION
### Motivation
- Prevent the magnified optic reticle from drawing to the lens when the mod is enabled but the player is not in ADS by stopping the original `OpticRetrice.OnPreCull()` draw path at its source.

### Description
- Add a Harmony prefix patch `OpticRetriceOnPreCullPatch` that targets `EFT.CameraControl.OpticRetrice.OnPreCull` and returns `false` whenever `ModEnabled` is true and the player is not scoped, preventing the vanilla reticle draw. (new file `Patches/OpticRetricePatch.cs`)
- Register the new patch in the startup patch registry by calling `SafeEnable<OpticRetriceOnPreCullPatch>()` from `Patches/Patcher.cs` so the behavior is applied with the rest of the mod patches.

### Testing
- Attempted `dotnet build PiPDisabler.csproj`, but the toolchain is not available in this environment so the build could not be executed. 
- Attempted `msbuild PiPDisabler.csproj /t:Build /p:Configuration=Debug`, but `msbuild` is not available in this environment so the build could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bac1941c00832893887e019d609686)