### PR TITLE
Clear vanilla optic state when PiP scope shuts down

### DIFF
--- a/Patches/PiPDisabler.cs
+++ b/Patches/PiPDisabler.cs
@@ -58,6 +58,8 @@ namespace PiPDisabler
         // Used to suppress our own OpticSight.OnDisable postfix (same-frame).
         private static readonly Dictionary<OpticSight, int> _ignoreOnDisableFrame =
             new Dictionary<OpticSight, int>(32);
+        private static readonly Dictionary<OpticSight, int> _allowLensFadeFrame =
+            new Dictionary<OpticSight, int>(32);
 
 internal static void TickBaseOpticCamera()
         {
@@ -139,6 +141,73 @@ internal static bool ShouldIgnoreOnDisable(OpticSight os)
 
     return false;
 }
+
+        internal static void CleanupVanillaOpticState(OpticSight opticSight)
+        {
+            try
+            {
+                if (!CameraClass.Exist) return;
+
+                var cameraClass = CameraClass.Instance;
+                if (cameraClass == null) return;
+
+                var manager = AccessTools.Property(cameraClass.GetType(), "OpticCameraManager")?.GetValue(cameraClass, null);
+                if (manager == null) return;
+
+                AccessTools.Property(manager.GetType(), "CurrentOpticSight")?.SetValue(manager, null, null);
+
+                var opticRetrice = GetMemberValue(manager, "OpticRetrice");
+                if (opticRetrice != null)
+                {
+                    AccessTools.Method(opticRetrice.GetType(), "SetOpticSight", new[] { typeof(OpticSight) })
+                        ?.Invoke(opticRetrice, new object[] { null });
+                    AccessTools.Method(opticRetrice.GetType(), "Clear")
+                        ?.Invoke(opticRetrice, null);
+                }
+
+                if (opticSight != null)
+                {
+                    _allowLensFadeFrame[opticSight] = Time.frameCount;
+                    opticSight.LensFade(true);
+                }
+            }
+            catch (Exception ex)
+            {
+                PiPDisablerPlugin.LogVerbose($"[PiPDisabler] Optic cleanup failed: {ex.Message}");
+            }
+        }
+
+        internal static bool ShouldAllowLensFade(OpticSight os)
+        {
+            if (os == null) return false;
+
+            if (_allowLensFadeFrame.TryGetValue(os, out var frame))
+            {
+                if (frame == Time.frameCount)
+                {
+                    _allowLensFadeFrame.Remove(os);
+                    return true;
+                }
+
+                if (Time.frameCount - frame > 10)
+                    _allowLensFadeFrame.Remove(os);
+            }
+
+            return false;
+        }
+
+        private static object GetMemberValue(object instance, string memberName)
+        {
+            if (instance == null || string.IsNullOrEmpty(memberName)) return null;
+
+            var type = instance.GetType();
+            var property = AccessTools.Property(type, memberName);
+            if (property != null)
+                return property.GetValue(instance, null);
+
+            var field = AccessTools.Field(type, memberName);
+            return field != null ? field.GetValue(instance) : null;
+        }
 
         private static void TryFindBaseOpticCameras()
         {
@@ -274,6 +343,7 @@ catch { /* ignore */ }
 
 _opticOrigEnabled.Clear();
 _ignoreOnDisableFrame.Clear();
+_allowLensFadeFrame.Clear();
 
             _cams.Clear();
 
@@ -416,6 +486,7 @@ _ignoreOnDisableFrame.Clear();
             private static bool Prefix(OpticSight __instance)
             {
                 if (ShouldAllowVanillaPiP()) return true;
+                if (ShouldAllowLensFade(__instance)) return true;
 
                 // In No-PiP mode, block LensFade to avoid material state issues.
                 // Lens hiding is handled by SSAA signal only — do NOT call

--- a/Patches/ScopeLifecycle.cs
+++ b/Patches/ScopeLifecycle.cs
@@ -747,6 +747,7 @@ namespace PiPDisabler
             // immediately on enter, but still restore when switching from a modded mode.
             if (restoreFov)
                 RestoreFov();
+            PiPDisabler.CleanupVanillaOpticState(os);
             Patches.WeaponScalingPatch.RestoreScale();
             ReticleRenderer.Cleanup();
             ScopeEffectsRenderer.Cleanup();
@@ -839,6 +840,7 @@ namespace PiPDisabler
             Patches.WeaponScalingPatch.RestoreScale();
 
             // 2. Hide reticle overlay + scope effects
+            PiPDisabler.CleanupVanillaOpticState(prevOptic);
             ReticleRenderer.Cleanup();
             ScopeEffectsRenderer.Cleanup();
 
@@ -938,6 +940,7 @@ namespace PiPDisabler
                 LensTransparency.ForceBlackLensMaterials(_activeOptic);
 
                 PiPDisablerPlugin.LogVerbose("[ScopeLifecycle] hiding reticle due to integrated-irons sub-scope");
+                PiPDisabler.CleanupVanillaOpticState(_activeOptic);
                 ReticleRenderer.Hide();
                 ScopeEffectsRenderer.Hide();
                 CameraSettingsManager.Restore();


### PR DESCRIPTION
### Motivation
- Prevent leftover red reticle artifacts by mirroring vanilla optic shutdown when the mod disables PiP or forces an unscoped state.

### Description
- Add `CleanupVanillaOpticState(OpticSight)` to `Patches/PiPDisabler.cs` that clears `OpticCameraManager.CurrentOpticSight`, calls `OpticRetrice.SetOpticSight(null)` and `OpticRetrice.Clear()`, and performs a one-shot `opticSight.LensFade(true)` while the usual LensFade block is active.
- Introduce `_allowLensFadeFrame` and `ShouldAllowLensFade` to permit the single-frame `LensFade` call, and clear that map during `RestoreAllCameras()` to avoid stale state.
- Add `GetMemberValue` helper for reflection-safe access to `OpticRetrice` and wire `CleanupVanillaOpticState` into scope lifecycle paths by calling it from `ApplyBypassState`, `DoScopeExit`, and the integrated-irons branch of `ApplyCurrentSubScopeVisualState` in `Patches/ScopeLifecycle.cs`.
- Allow the existing `OpticSight.LensFade` prefix patch to pass when `ShouldAllowLensFade` returns true so the one-shot fade runs.

### Testing
- Attempted `dotnet build PiPDisabler.csproj` but `dotnet` is not installed in the container so a full compile could not be performed.
- Verified changes by inspecting diffs with `git diff` and reviewing modified files via `nl -ba ... | sed -n ...` and committed the changes with message `Clear vanilla optic state when PiP scope shuts down`.
- No automated runtime tests were executed due to missing .NET toolchain in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bac464db4083288fcadf5d1e15d5c0)