### PR TITLE
Smooth weapon scaling transitions

### DIFF
--- a/Patches/WeaponScalingPatch.cs
+++ b/Patches/WeaponScalingPatch.cs
@@ -34,7 +34,7 @@ namespace PiPDisabler.Patches
     /// the visual fields:
     ///
     ///   RibcageScaleCurrentTarget = ourScale
-    ///   RibcageScaleCurrent       = ourScale   (instant snap, no lerp)
+    ///   RibcageScaleCurrent       = ourScale   (smoothed locally, EFT lerp bypassed)
     ///
     /// This makes the weapon model shrink without moving the reticle/aim point.
     ///
@@ -44,6 +44,9 @@ namespace PiPDisabler.Patches
     internal sealed class WeaponScalingPatch : ModulePatch
     {
         private static bool _isActive;
+        private static bool _hasSmoothedScale;
+        private static float _smoothedScale;
+        private static float _smoothedScaleVelocity;
 
         // Zoom formula baseline (must match FovController.ZoomBaselineFov)
         private const float ZoomBaseline = 50f;
@@ -60,13 +63,32 @@ namespace PiPDisabler.Patches
         {
             if (!PiPDisablerPlugin.EnableWeaponScaling.Value) return;
             var os = ScopeLifecycle.ActiveOptic;
-            if (os == null) { _isActive = false; return; }
+            if (os == null)
+            {
+                _isActive = false;
+                _hasSmoothedScale = false;
+                _smoothedScaleVelocity = 0f;
+                return;
+            }
+
+            var player = GetMainPlayer();
+            if (player != null)
+            {
+                _smoothedScale = player.RibcageScaleCurrent;
+                _hasSmoothedScale = true;
+            }
+            else
+            {
+                _hasSmoothedScale = false;
+            }
+
+            _smoothedScaleVelocity = 0f;
             _isActive = true;
         }
 
         /// <summary>
         /// Per-frame update: override visual ribcage scale with our computed value.
-        /// Snaps both fields so there's no lerp delay.
+        /// Smoothing is applied locally to match the FOV transition more closely.
         /// Called from ScopeLifecycle.Tick().
         /// </summary>
         public static void UpdateScale()
@@ -81,11 +103,12 @@ namespace PiPDisabler.Patches
                 if (!CameraClass.Exist) return;
 
                 float currentFov = CameraClass.Instance.Fov;
-                float scale = ComputeCompensatedScale(currentFov);
+                float targetScale = ComputeCompensatedScale(currentFov);
+                float scale = SmoothScale(player, targetScale);
 
                 // Override ONLY visual fields — aim math (_compensatoryScale etc.) untouched
                 player.RibcageScaleCurrentTarget = scale;
-                player.RibcageScaleCurrent = scale; // instant snap
+                player.RibcageScaleCurrent = scale;
             }
             catch { }
         }
@@ -97,6 +120,8 @@ namespace PiPDisabler.Patches
         public static void RestoreScale()
         {
             _isActive = false;
+            _hasSmoothedScale = false;
+            _smoothedScaleVelocity = 0f;
 
             try
             {
@@ -164,13 +189,48 @@ namespace PiPDisabler.Patches
                 if (!CameraClass.Exist) return;
 
                 float currentFov = CameraClass.Instance.Fov;
-                float scale = ComputeCompensatedScale(currentFov);
+                float targetScale = ComputeCompensatedScale(currentFov);
+                float scale = SmoothScale(__instance, targetScale);
 
                 // Override visual scale AFTER EFT has finished all aim math
                 __instance.RibcageScaleCurrentTarget = scale;
-                __instance.RibcageScaleCurrent = scale; // instant snap
+                __instance.RibcageScaleCurrent = scale;
             }
             catch { }
+        }
+
+        private static float SmoothScale(Player player, float targetScale)
+        {
+            float duration = PiPDisablerPlugin.WeaponScaleSmoothingDuration.Value;
+            if (duration <= 0f)
+            {
+                _smoothedScale = targetScale;
+                _smoothedScaleVelocity = 0f;
+                _hasSmoothedScale = true;
+                return targetScale;
+            }
+
+            if (!_hasSmoothedScale)
+            {
+                _smoothedScale = player != null ? player.RibcageScaleCurrent : targetScale;
+                _hasSmoothedScale = true;
+            }
+
+            float deltaTime = Time.deltaTime;
+            if (deltaTime <= 0f)
+                deltaTime = Time.unscaledDeltaTime;
+            if (deltaTime <= 0f)
+                return _smoothedScale;
+
+            _smoothedScale = Mathf.SmoothDamp(
+                _smoothedScale,
+                targetScale,
+                ref _smoothedScaleVelocity,
+                duration,
+                Mathf.Infinity,
+                deltaTime);
+
+            return _smoothedScale;
         }
 
         private static Player GetMainPlayer()

--- a/Patches/WeaponScalingPatch.cs
+++ b/Patches/WeaponScalingPatch.cs
@@ -34,7 +34,7 @@ namespace PiPDisabler.Patches
     /// the visual fields:
     ///
     ///   RibcageScaleCurrentTarget = ourScale
-    ///   RibcageScaleCurrent       = ourScale   (smoothed locally, EFT lerp bypassed)
+    ///   RibcageScaleCurrent       = ourScale   (matched to live camera FOV)
     ///
     /// This makes the weapon model shrink without moving the reticle/aim point.
     ///
@@ -44,9 +44,6 @@ namespace PiPDisabler.Patches
     internal sealed class WeaponScalingPatch : ModulePatch
     {
         private static bool _isActive;
-        private static bool _hasSmoothedScale;
-        private static float _smoothedScale;
-        private static float _smoothedScaleVelocity;
 
         // Zoom formula baseline (must match FovController.ZoomBaselineFov)
         private const float ZoomBaseline = 50f;
@@ -66,29 +63,18 @@ namespace PiPDisabler.Patches
             if (os == null)
             {
                 _isActive = false;
-                _hasSmoothedScale = false;
-                _smoothedScaleVelocity = 0f;
                 return;
             }
 
             var player = GetMainPlayer();
-            if (player != null)
-            {
-                _smoothedScale = player.RibcageScaleCurrent;
-                _hasSmoothedScale = true;
-            }
-            else
-            {
-                _hasSmoothedScale = false;
-            }
-
-            _smoothedScaleVelocity = 0f;
             _isActive = true;
+
+            if (player == null || !CameraClass.Exist) return;
+            ApplyScale(player, CameraClass.Instance.Fov);
         }
 
         /// <summary>
         /// Per-frame update: override visual ribcage scale with our computed value.
-        /// Smoothing is applied locally to match the FOV transition more closely.
         /// Called from ScopeLifecycle.Tick().
         /// </summary>
         public static void UpdateScale()
@@ -102,13 +88,7 @@ namespace PiPDisabler.Patches
                 if (player == null) return;
                 if (!CameraClass.Exist) return;
 
-                float currentFov = CameraClass.Instance.Fov;
-                float targetScale = ComputeCompensatedScale(currentFov);
-                float scale = SmoothScale(player, targetScale);
-
-                // Override ONLY visual fields — aim math (_compensatoryScale etc.) untouched
-                player.RibcageScaleCurrentTarget = scale;
-                player.RibcageScaleCurrent = scale;
+                ApplyScale(player, CameraClass.Instance.Fov);
             }
             catch { }
         }
@@ -120,8 +100,6 @@ namespace PiPDisabler.Patches
         public static void RestoreScale()
         {
             _isActive = false;
-            _hasSmoothedScale = false;
-            _smoothedScaleVelocity = 0f;
 
             try
             {
@@ -188,49 +166,16 @@ namespace PiPDisabler.Patches
                 if (!_isActive) return;
                 if (!CameraClass.Exist) return;
 
-                float currentFov = CameraClass.Instance.Fov;
-                float targetScale = ComputeCompensatedScale(currentFov);
-                float scale = SmoothScale(__instance, targetScale);
-
-                // Override visual scale AFTER EFT has finished all aim math
-                __instance.RibcageScaleCurrentTarget = scale;
-                __instance.RibcageScaleCurrent = scale;
+                ApplyScale(__instance, CameraClass.Instance.Fov);
             }
             catch { }
         }
 
-        private static float SmoothScale(Player player, float targetScale)
+        private static void ApplyScale(Player player, float currentFov)
         {
-            float duration = PiPDisablerPlugin.WeaponScaleSmoothingDuration.Value;
-            if (duration <= 0f)
-            {
-                _smoothedScale = targetScale;
-                _smoothedScaleVelocity = 0f;
-                _hasSmoothedScale = true;
-                return targetScale;
-            }
-
-            if (!_hasSmoothedScale)
-            {
-                _smoothedScale = player != null ? player.RibcageScaleCurrent : targetScale;
-                _hasSmoothedScale = true;
-            }
-
-            float deltaTime = Time.deltaTime;
-            if (deltaTime <= 0f)
-                deltaTime = Time.unscaledDeltaTime;
-            if (deltaTime <= 0f)
-                return _smoothedScale;
-
-            _smoothedScale = Mathf.SmoothDamp(
-                _smoothedScale,
-                targetScale,
-                ref _smoothedScaleVelocity,
-                duration,
-                Mathf.Infinity,
-                deltaTime);
-
-            return _smoothedScale;
+            float scale = ComputeCompensatedScale(currentFov);
+            player.RibcageScaleCurrentTarget = scale;
+            player.RibcageScaleCurrent = scale;
         }
 
         private static Player GetMainPlayer()

--- a/PiPDisablerPlugin.cs
+++ b/PiPDisablerPlugin.cs
@@ -206,7 +206,6 @@ namespace PiPDisabler
         internal static ConfigEntry<bool> EnableWeaponScaling;
         internal static ConfigEntry<float> BaselineWeaponScale;
         internal static ConfigEntry<float> WeaponScaleStrength;
-        internal static ConfigEntry<float> WeaponScaleSmoothingDuration;
         // --- Zoom / FOV ---
         internal static ConfigEntry<bool> EnableZoom;
         internal static ConfigEntry<float> DefaultZoom;
@@ -326,12 +325,6 @@ namespace PiPDisabler
                     "Blends between no compensation and full inverse-FOV compensation.\n" +
                     "0.00 = no compensation, 1.00 = full compensation, values outside [0,1] over/under-compensate.",
                     new AcceptableValueRange<float>(-2.00f, 2.00f),
-                    new ConfigurationManagerAttributes { IsAdvanced = true }));
-            WeaponScaleSmoothingDuration = Config.Bind("General", "WeaponScaleSmoothingDuration", 0.08f,
-                new ConfigDescription(
-                    "Seconds used to smooth weapon scale changes while scoped.\n" +
-                    "0.00 = instant snap, higher values ease magnification and mode-switch transitions.",
-                    new AcceptableValueRange<float>(0f, 1f),
                     new ConfigurationManagerAttributes { IsAdvanced = true }));
 
             // --- Zoom ---

--- a/PiPDisablerPlugin.cs
+++ b/PiPDisablerPlugin.cs
@@ -206,6 +206,7 @@ namespace PiPDisabler
         internal static ConfigEntry<bool> EnableWeaponScaling;
         internal static ConfigEntry<float> BaselineWeaponScale;
         internal static ConfigEntry<float> WeaponScaleStrength;
+        internal static ConfigEntry<float> WeaponScaleSmoothingDuration;
         // --- Zoom / FOV ---
         internal static ConfigEntry<bool> EnableZoom;
         internal static ConfigEntry<float> DefaultZoom;
@@ -325,6 +326,12 @@ namespace PiPDisabler
                     "Blends between no compensation and full inverse-FOV compensation.\n" +
                     "0.00 = no compensation, 1.00 = full compensation, values outside [0,1] over/under-compensate.",
                     new AcceptableValueRange<float>(-2.00f, 2.00f),
+                    new ConfigurationManagerAttributes { IsAdvanced = true }));
+            WeaponScaleSmoothingDuration = Config.Bind("General", "WeaponScaleSmoothingDuration", 0.08f,
+                new ConfigDescription(
+                    "Seconds used to smooth weapon scale changes while scoped.\n" +
+                    "0.00 = instant snap, higher values ease magnification and mode-switch transitions.",
+                    new AcceptableValueRange<float>(0f, 1f),
                     new ConfigurationManagerAttributes { IsAdvanced = true }));
 
             // --- Zoom ---


### PR DESCRIPTION
### Motivation
- Weapon visual scale currently snaps instantly when FOV/magnification changes, producing abrupt visual transitions during ADS/mode switches. 
- Add a small, configurable smoothing layer so the visual ribcage/weapon scale eases in a way that better matches the FOV animation while leaving aim math untouched.

### Description
- Added a `WeaponScaleSmoothingDuration` config entry (default `0.08f`) to `PiPDisablerPlugin.cs` so smoothing can be tuned without code changes.
- Implemented local smoothing state (`_hasSmoothedScale`, `_smoothedScale`, `_smoothedScaleVelocity`) in `Patches/WeaponScalingPatch.cs` and initialize/reset it on scope enter/exit.
- Replaced instant snaps with a `SmoothScale` helper that uses `Mathf.SmoothDamp` (falls back to `Time.unscaledDeltaTime` if `Time.deltaTime` is zero) and applied it from both the per-frame `UpdateScale()` and the Harmony `Postfix` so visual fields (`RibcageScaleCurrentTarget` and `RibcageScaleCurrent`) are smoothed while aim math remains untouched.
- Minor comment updates to reflect the new smoothing behavior.

### Testing
- Ran `git diff --check` with no problems reported. 
- Attempted a project build with `dotnet build PiPDisabler.csproj`, but the environment lacked the `dotnet` SDK so the build could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bac8402e448328b63eb9ab9faa5643)