### PR TITLE
Fix reticle hide during optic mode switches

### DIFF
--- a/Patches/ScopeLifecycle.cs
+++ b/Patches/ScopeLifecycle.cs
@@ -236,8 +236,12 @@ namespace PiPDisabler
         /// </summary>
         public static void OnOpticDisabled(OpticSight os)
         {
-            ReticleRenderer.Hide();
-            ScopeEffectsRenderer.Hide();
+            if (os == _activeOptic)
+            {
+                ReticleRenderer.Hide();
+                ScopeEffectsRenderer.Hide();
+            }
+
             CheckAndUpdate("OnOpticDisabled");
         }
 


### PR DESCRIPTION
### Motivation
- Switching between integrated irons and an optic could leave one magnification without a reticle because EFT sometimes disables the outgoing `OpticSight` after the incoming sight is already active, and `OnOpticDisabled` previously tore down overlays unconditionally.

### Description
- Guard `ScopeLifecycle.OnOpticDisabled` so `ReticleRenderer.Hide()` and `ScopeEffectsRenderer.Hide()` are only called when the disabled `OpticSight` equals the tracked `_activeOptic`, preventing the outgoing sight from removing overlays for the newly active mode.

### Testing
- Attempted `dotnet build PiPDisabler.csproj` in this environment and it failed because `dotnet` is not installed, so no build/test was executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bacbb8815c8328908d5593753d46b3)