### PR TITLE
Keep weapon scaling synced during unscope

### DIFF
--- a/Patches/ScopeLifecycle.cs
+++ b/Patches/ScopeLifecycle.cs
@@ -379,9 +379,6 @@ namespace PiPDisabler
 
             // PiP stays disabled via Harmony patches — no per-frame action needed.
 
-            // Per-frame weapon scale compensation (tracks animated FOV transitions)
-            Patches.WeaponScalingPatch.UpdateScale();
-
             // Zeroing input polling
             ZeroingController.Tick();
         }
@@ -836,8 +833,8 @@ namespace PiPDisabler
             // 1. Restore FOV with ADS-matched animation timing
             RestoreFov();
 
-            // 1b. Restore normal weapon model scaling (after FOV is back to normal)
-            Patches.WeaponScalingPatch.RestoreScale();
+            // 1b. Keep weapon scaling synced with the unscope FOV animation.
+            Patches.WeaponScalingPatch.BeginRestore(PiPDisablerPlugin.FovAnimationDuration.Value);
 
             // 2. Hide reticle overlay + scope effects
             PiPDisabler.CleanupVanillaOpticState(prevOptic);

--- a/Patches/ScopeLifecycle.cs
+++ b/Patches/ScopeLifecycle.cs
@@ -833,8 +833,8 @@ namespace PiPDisabler
             // 1. Restore FOV with ADS-matched animation timing
             RestoreFov();
 
-            // 1b. Keep weapon scaling synced with the unscope FOV animation.
-            Patches.WeaponScalingPatch.BeginRestore(PiPDisablerPlugin.FovAnimationDuration.Value);
+            // 1b. Keep weapon scaling synced until the camera reaches baseline FOV.
+            Patches.WeaponScalingPatch.BeginRestore();
 
             // 2. Hide reticle overlay + scope effects
             PiPDisabler.CleanupVanillaOpticState(prevOptic);

--- a/Patches/WeaponScalingPatch.cs
+++ b/Patches/WeaponScalingPatch.cs
@@ -44,10 +44,11 @@ namespace PiPDisabler.Patches
     internal sealed class WeaponScalingPatch : ModulePatch
     {
         private static bool _isActive;
-        private static float _restoreDeadline = -1f;
+        private static float _restoreTargetFov = -1f;
 
         // Zoom formula baseline (must match FovController.ZoomBaselineFov)
         private const float ZoomBaseline = 50f;
+        private const float RestoreFovEpsilon = 0.05f;
 
         protected override MethodBase GetTargetMethod()
         {
@@ -63,13 +64,13 @@ namespace PiPDisabler.Patches
             var os = ScopeLifecycle.ActiveOptic;
             if (os == null) { _isActive = false; return; }
             _isActive = true;
-            _restoreDeadline = -1f;
+            _restoreTargetFov = -1f;
         }
 
         /// <summary>
         /// Per-frame update: override visual ribcage scale with our computed value.
         /// Snaps both fields so there's no lerp delay.
-        /// Called from ScopeLifecycle.Tick().
+        /// Called from the plugin update loop.
         /// </summary>
         public static void UpdateScale()
         {
@@ -84,23 +85,26 @@ namespace PiPDisabler.Patches
                 if (!CameraClass.Exist) return;
 
                 float currentFov = CameraClass.Instance.Fov;
+                if (_restoreTargetFov >= 0f &&
+                    currentFov >= _restoreTargetFov - RestoreFovEpsilon)
+                {
+                    RestoreScale();
+                    return;
+                }
+
                 float scale = ComputeCompensatedScale(currentFov);
 
                 // Override ONLY visual fields — aim math (_compensatoryScale etc.) untouched
                 player.RibcageScaleCurrentTarget = scale;
                 player.RibcageScaleCurrent = scale; // instant snap
-
-                if (_restoreDeadline >= 0f && Time.unscaledTime >= _restoreDeadline)
-                    RestoreScale();
             }
             catch { }
         }
 
         /// <summary>
-        /// Keep matching the animated camera FOV until the unscope transition ends.
-        /// Called from ScopeLifecycle.DoScopeExit after RestoreFov starts.
+        /// Keep matching the camera FOV until unscope reaches the baseline FOV.
         /// </summary>
-        public static void BeginRestore(float duration)
+        public static void BeginRestore()
         {
             if (!_isActive)
             {
@@ -108,7 +112,15 @@ namespace PiPDisabler.Patches
                 return;
             }
 
-            _restoreDeadline = Time.unscaledTime + Mathf.Max(0f, duration);
+            var player = GetMainPlayer();
+            var pwa = player != null ? player.ProceduralWeaponAnimation : null;
+            if (pwa == null)
+            {
+                RestoreScale();
+                return;
+            }
+
+            _restoreTargetFov = pwa.Single_2;
         }
 
         /// <summary>
@@ -117,7 +129,7 @@ namespace PiPDisabler.Patches
         public static void RestoreScale()
         {
             _isActive = false;
-            _restoreDeadline = -1f;
+            _restoreTargetFov = -1f;
 
             try
             {

--- a/Patches/WeaponScalingPatch.cs
+++ b/Patches/WeaponScalingPatch.cs
@@ -44,6 +44,7 @@ namespace PiPDisabler.Patches
     internal sealed class WeaponScalingPatch : ModulePatch
     {
         private static bool _isActive;
+        private static float _restoreDeadline = -1f;
 
         // Zoom formula baseline (must match FovController.ZoomBaselineFov)
         private const float ZoomBaseline = 50f;
@@ -62,6 +63,7 @@ namespace PiPDisabler.Patches
             var os = ScopeLifecycle.ActiveOptic;
             if (os == null) { _isActive = false; return; }
             _isActive = true;
+            _restoreDeadline = -1f;
         }
 
         /// <summary>
@@ -71,11 +73,12 @@ namespace PiPDisabler.Patches
         /// </summary>
         public static void UpdateScale()
         {
-            if (!_isActive) return;
             if (!PiPDisablerPlugin.EnableWeaponScaling.Value) return;
 
             try
             {
+                if (!_isActive) return;
+
                 var player = GetMainPlayer();
                 if (player == null) return;
                 if (!CameraClass.Exist) return;
@@ -86,17 +89,35 @@ namespace PiPDisabler.Patches
                 // Override ONLY visual fields — aim math (_compensatoryScale etc.) untouched
                 player.RibcageScaleCurrentTarget = scale;
                 player.RibcageScaleCurrent = scale; // instant snap
+
+                if (_restoreDeadline >= 0f && Time.unscaledTime >= _restoreDeadline)
+                    RestoreScale();
             }
             catch { }
         }
 
         /// <summary>
+        /// Keep matching the animated camera FOV until the unscope transition ends.
+        /// Called from ScopeLifecycle.DoScopeExit after RestoreFov starts.
+        /// </summary>
+        public static void BeginRestore(float duration)
+        {
+            if (!_isActive)
+            {
+                RestoreScale();
+                return;
+            }
+
+            _restoreDeadline = Time.unscaledTime + Mathf.Max(0f, duration);
+        }
+
+        /// <summary>
         /// Restore normal EFT ribcage scaling.
-        /// Called from ScopeLifecycle.DoScopeExit.
         /// </summary>
         public static void RestoreScale()
         {
             _isActive = false;
+            _restoreDeadline = -1f;
 
             try
             {

--- a/PiPDisablerPlugin.cs
+++ b/PiPDisablerPlugin.cs
@@ -1024,6 +1024,9 @@ namespace PiPDisabler
 
             // Per-frame maintenance (ensure lens hidden, update variable zoom, etc.)
             ScopeLifecycle.Tick();
+
+            // Keep weapon scale synced during scope enter/exit FOV animations.
+            Patches.WeaponScalingPatch.UpdateScale();
         }
         private static bool IsInRaid()
         {


### PR DESCRIPTION
### Motivation
- UnADS felt visually wrong because the weapon model scale snapped back immediately while the camera FOV continued its unscope animation, creating an inconsistent perceived magnification change.
- The change aims to keep visual ribcage/weapon scaling matched to the animated camera FOV throughout the unscope transition so the weapon size interpolates smoothly back to normal.

### Description
- Add a `_restoreDeadline` and `BeginRestore(float duration)` in `Patches/WeaponScalingPatch.cs` to delay restoring EFT's normal ribcage scaling until the unscope animation duration elapses.
- Continue driving visual weapon scale from `WeaponScalingPatch.UpdateScale()` and make it check the restore deadline and call `RestoreScale()` when expired; ensure `CaptureBaseState()` resets the deadline.
- Call `WeaponScalingPatch.BeginRestore(PiPDisablerPlugin.FovAnimationDuration.Value)` from `Patches/ScopeLifecycle.cs` when unscoping instead of restoring immediately so scaling stays in sync with `RestoreFov()`.
- Move a per-frame call to `Patches.WeaponScalingPatch.UpdateScale()` into the main loop in `PiPDisablerPlugin.cs` so scaling updates continue to run during the post-scope FOV animation.

### Testing
- Attempted an automated build with `dotnet build PiPDisabler.csproj`, but the environment lacks `dotnet` so the build could not be executed.
- No other automated tests were available in this environment, changes were validated by reviewing the resulting diffs and ensuring the new restore flow and call sites are present.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bacc7e1c4083288e7ae8abd7f2aa26)