### PR TITLE
Cleanup vanilla optic state on PiP shutdown and remove black-lens option

### DIFF
--- a/Patches/LensTransparency.cs
+++ b/Patches/LensTransparency.cs
@@ -48,20 +48,6 @@ namespace PiPDisabler
         private static readonly int _propColor = Shader.PropertyToID("_Color");
         private static readonly int _propSwitchToSight = Shader.PropertyToID("_SwitchToSight");
 
-        // Truly original materials per renderer, stored once on first KillMesh call.
-        // Prevents the black material we apply on RestoreAll from being mistaken for
-        // the original if the player scopes in again on the same session.
-        private static readonly Dictionary<int, Material[]> _trulyOriginalMaterials =
-            new Dictionary<int, Material[]>();
-
-        // Renderers that currently have the black material applied (scope not in use).
-        // Tracked so we can restore them before ReticleRenderer reads textures on scope entry,
-        // and so we can fully clean up when the mod is disabled.
-        private static readonly HashSet<Renderer> _blackenedRenderers = new HashSet<Renderer>();
-
-        // Solid black unlit material applied to lens surfaces when unscoped.
-        private static Material _blackLensMaterial;
-
         private static Mesh GetEmptyMesh()
         {
             if (_emptyMesh != null) return _emptyMesh;
@@ -71,80 +57,12 @@ namespace PiPDisabler
             return _emptyMesh;
         }
 
-        private static Material GetBlackLensMaterial()
-        {
-            if (_blackLensMaterial != null) return _blackLensMaterial;
-            // Unlit/Color: solid color, no lighting, no texture — guaranteed opaque black.
-            // Falls back to Standard if Unlit/Color isn't in the build's shader set.
-            var shader = Shader.Find("Unlit/Color") ?? Shader.Find("Standard");
-            _blackLensMaterial = new Material(shader)
-            {
-                name  = "PiPDisabler_BlackLens",
-                color = Color.black,
-            };
-            return _blackLensMaterial;
-        }
-
         /// <summary>
-        /// Replace all material slots on <paramref name="r"/> with a solid black unlit material.
-        /// Records the renderer in _blackenedRenderers so it can be un-blackened later.
-        /// </summary>
-        private static void ApplyBlackMaterial(Renderer r)
-        {
-            if (r == null) return;
-            try
-            {
-                var blackMat = GetBlackLensMaterial();
-                int slotCount = 1;
-                try { slotCount = r.sharedMaterials.Length; } catch { }
-                if (slotCount < 1) slotCount = 1;
-
-                var blackArray = new Material[slotCount];
-                for (int i = 0; i < slotCount; i++)
-                    blackArray[i] = blackMat;
-
-                r.sharedMaterials = blackArray;
-                _blackenedRenderers.Add(r);
-            }
-            catch { }
-        }
-
-        /// <summary>
-        /// Restores the original sharedMaterials on any lens renderers that currently have
-        /// the black material applied.  Call this at scope ENTRY, before
-        /// ReticleRenderer.ExtractReticle(), so the texture read sees the real OpticSight
-        /// material rather than our Unlit/Color placeholder.
-        /// </summary>
-        public static void RestoreBlackLensMaterials()
-        {
-            if (_blackenedRenderers.Count == 0) return;
-            foreach (var r in _blackenedRenderers)
-            {
-                if (r == null) continue;
-                int rid = r.GetInstanceID();
-                Material[] origMats;
-                if (_trulyOriginalMaterials.TryGetValue(rid, out origMats) && origMats != null)
-                {
-                    try { r.sharedMaterials = origMats; }
-                    catch { }
-                }
-            }
-            _blackenedRenderers.Clear();
-            PiPDisablerPlugin.LogInfo(
-                "[LensTransparency] Restored original materials before scope entry");
-        }
-
-        /// <summary>
-        /// Full cleanup: restores original materials and clears all internal caches.
-        /// Call when the mod is disabled or the plugin is destroyed so EFT's native
-        /// PiP rendering can use the lens normally.
+        /// Full cleanup for shutdown or mod disable.
         /// </summary>
         public static void FullRestoreAll()
         {
-            RestoreBlackLensMaterials(); // also clears _blackenedRenderers
-            _trulyOriginalMaterials.Clear();
-            PiPDisablerPlugin.LogInfo(
-                "[LensTransparency] FullRestoreAll: caches cleared");
+            RestoreAll();
         }
 
         /// <summary>
@@ -242,21 +160,10 @@ namespace PiPDisabler
 
         /// <summary>
         /// Restore all. Called on scope exit.
-        ///
-        /// When BlackLensWhenUnscoped is enabled (default), the lens geometry is
-        /// restored but an opaque black material is applied in place of the original
-        /// PiP/sight material.  This prevents the reticle-flash that occurs during
-        /// the unscope transition and matches the real-world appearance of scope
-        /// glass viewed from outside.  The truly original materials are kept in
-        /// _trulyOriginalMaterials so the next scope-enter always saves the correct
-        /// originals rather than the black placeholder.
         /// </summary>
         public static void RestoreAll()
         {
             if (_hidden.Count == 0) return;
-
-            bool blackLens = PiPDisablerPlugin.BlackLensWhenUnscoped != null
-                             && PiPDisablerPlugin.BlackLensWhenUnscoped.Value;
 
             for (int i = 0; i < _hidden.Count; i++)
             {
@@ -279,35 +186,20 @@ namespace PiPDisabler
 
                     if (e.Renderer != null)
                     {
-                        // Re-enable rendering (lens is visible when unscoped).
                         e.Renderer.forceRenderingOff = e.WasForceOff;
-
-                        if (blackLens)
+                        if (e.OriginalMaterials != null)
                         {
-                            // Apply solid black material — no PiP texture, no reticle flash.
-                            ApplyBlackMaterial(e.Renderer);
-                            PiPDisablerPlugin.LogVerbose(
-                                $"[LensTransparency] Applied black lens to '{e.Renderer.gameObject.name}'");
+                            try { e.Renderer.sharedMaterials = e.OriginalMaterials; }
+                            catch { }
                         }
-                        else
-                        {
-                            // Restore original shared materials (legacy path).
-                            if (e.OriginalMaterials != null)
-                            {
-                                try { e.Renderer.sharedMaterials = e.OriginalMaterials; }
-                                catch { }
-                            }
-                            PiPDisablerPlugin.LogVerbose(
-                                $"[LensTransparency] Restored renderer '{e.Renderer.gameObject.name}' forceOff={e.WasForceOff}");
-                        }
+                        PiPDisablerPlugin.LogVerbose(
+                            $"[LensTransparency] Restored renderer '{e.Renderer.gameObject.name}' forceOff={e.WasForceOff}");
                     }
                 }
                 catch { }
             }
 
-            PiPDisablerPlugin.LogInfo(
-                $"[LensTransparency] Restored {_hidden.Count} lens meshes" +
-                (blackLens ? " (black lens applied)" : ""));
+            PiPDisablerPlugin.LogInfo($"[LensTransparency] Restored {_hidden.Count} lens meshes");
             _hidden.Clear();
         }
 
@@ -336,20 +228,8 @@ namespace PiPDisabler
                 mf.sharedMesh = GetEmptyMesh();
             }
 
-            // Save the TRULY ORIGINAL shared materials only on first encounter.
-            // On subsequent scope-ins the renderer may already have the black material
-            // we applied on the previous scope-exit — we must not overwrite the cache.
-            int rid = r.GetInstanceID();
-            if (!_trulyOriginalMaterials.ContainsKey(rid))
-            {
-                Material[] firstSeenMats = null;
-                try { firstSeenMats = r.sharedMaterials; } catch { }
-                if (firstSeenMats != null)
-                    _trulyOriginalMaterials[rid] = firstSeenMats;
-            }
-
             Material[] origMats = null;
-            _trulyOriginalMaterials.TryGetValue(rid, out origMats);
+            try { origMats = r.sharedMaterials; } catch { }
 
             var entry = new HiddenEntry
             {

--- a/Patches/PiPDisabler.cs
+++ b/Patches/PiPDisabler.cs
@@ -59,6 +59,18 @@ namespace PiPDisabler
         private static readonly Dictionary<OpticSight, int> _ignoreOnDisableFrame =
             new Dictionary<OpticSight, int>(32);
 
+        private static PropertyInfo _opticCameraManagerProperty;
+        private static bool _opticCameraManagerSearched;
+        private static MemberInfo _currentOpticSightMember;
+        private static bool _currentOpticSightSearched;
+        private static MemberInfo _opticRetriceMember;
+        private static bool _opticRetriceSearched;
+        private static MethodInfo _opticRetriceSetOpticSightMethod;
+        private static bool _opticRetriceSetOpticSightSearched;
+        private static MethodInfo _opticRetriceClearMethod;
+        private static bool _opticRetriceClearSearched;
+        private static bool _allowForcedLensFade;
+
 internal static void TickBaseOpticCamera()
         {
             if (!PiPDisablerPlugin.DisablePiP.Value) return;
@@ -139,6 +151,143 @@ internal static bool ShouldIgnoreOnDisable(OpticSight os)
 
     return false;
 }
+
+        internal static void CleanupVanillaOpticState(OpticSight opticSight)
+        {
+            try
+            {
+                var manager = GetOpticCameraManager();
+                if (manager != null)
+                {
+                    SetCurrentOpticSight(manager, null);
+
+                    var opticRetrice = GetOpticRetrice(manager);
+                    if (opticRetrice != null)
+                    {
+                        SetOpticRetriceSight(opticRetrice, null);
+                        ClearOpticRetrice(opticRetrice);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                PiPDisablerPlugin.LogVerbose(
+                    $"[PiPDisabler] Vanilla optic cleanup failed: {ex.Message}");
+            }
+
+            if (opticSight != null)
+            {
+                try
+                {
+                    _allowForcedLensFade = true;
+                    opticSight.LensFade(true);
+                }
+                catch { }
+                finally { _allowForcedLensFade = false; }
+            }
+        }
+
+        internal static bool ShouldAllowForcedLensFade()
+            => _allowForcedLensFade;
+
+        private static object GetOpticCameraManager()
+        {
+            if (!CameraClass.Exist) return null;
+
+            var cameraClass = CameraClass.Instance;
+            if (cameraClass == null) return null;
+
+            if (!_opticCameraManagerSearched)
+            {
+                _opticCameraManagerSearched = true;
+                _opticCameraManagerProperty = cameraClass.GetType().GetProperty(
+                    "OpticCameraManager",
+                    BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            }
+
+            return _opticCameraManagerProperty != null
+                ? _opticCameraManagerProperty.GetValue(cameraClass, null)
+                : null;
+        }
+
+        private static void SetCurrentOpticSight(object manager, object value)
+        {
+            if (manager == null) return;
+
+            if (!_currentOpticSightSearched)
+            {
+                _currentOpticSightSearched = true;
+                var flags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
+                var type = manager.GetType();
+                _currentOpticSightMember = (MemberInfo)type.GetProperty("CurrentOpticSight", flags)
+                    ?? type.GetField("CurrentOpticSight", flags);
+            }
+
+            if (_currentOpticSightMember is PropertyInfo property)
+            {
+                property.SetValue(manager, value, null);
+            }
+            else if (_currentOpticSightMember is FieldInfo field)
+            {
+                field.SetValue(manager, value);
+            }
+        }
+
+        private static object GetOpticRetrice(object manager)
+        {
+            if (manager == null) return null;
+
+            if (!_opticRetriceSearched)
+            {
+                _opticRetriceSearched = true;
+                var flags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
+                var type = manager.GetType();
+                _opticRetriceMember = (MemberInfo)type.GetProperty("OpticRetrice", flags)
+                    ?? type.GetField("OpticRetrice", flags);
+            }
+
+            if (_opticRetriceMember is PropertyInfo property)
+                return property.GetValue(manager, null);
+            if (_opticRetriceMember is FieldInfo field)
+                return field.GetValue(manager);
+            return null;
+        }
+
+        private static void SetOpticRetriceSight(object opticRetrice, OpticSight opticSight)
+        {
+            if (opticRetrice == null) return;
+
+            if (!_opticRetriceSetOpticSightSearched)
+            {
+                _opticRetriceSetOpticSightSearched = true;
+                _opticRetriceSetOpticSightMethod = opticRetrice.GetType().GetMethod(
+                    "SetOpticSight",
+                    BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+                    null,
+                    new[] { typeof(OpticSight) },
+                    null);
+            }
+
+            _opticRetriceSetOpticSightMethod?.Invoke(opticRetrice, new object[] { opticSight });
+        }
+
+        private static void ClearOpticRetrice(object opticRetrice)
+        {
+            if (opticRetrice == null) return;
+
+            if (!_opticRetriceClearSearched)
+            {
+                _opticRetriceClearSearched = true;
+                _opticRetriceClearMethod = opticRetrice.GetType().GetMethod(
+                    "Clear",
+                    BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+                    null,
+                    Type.EmptyTypes,
+                    null);
+            }
+
+            _opticRetriceClearMethod?.Invoke(opticRetrice, null);
+        }
 
         private static void TryFindBaseOpticCameras()
         {
@@ -415,7 +564,7 @@ _ignoreOnDisableFrame.Clear();
             [PatchPrefix]
             private static bool Prefix(OpticSight __instance)
             {
-                if (ShouldAllowVanillaPiP()) return true;
+                if (ShouldAllowVanillaPiP() || PiPDisabler.ShouldAllowForcedLensFade()) return true;
 
                 // In No-PiP mode, block LensFade to avoid material state issues.
                 // Lens hiding is handled by SSAA signal only — do NOT call

--- a/Patches/ScopeLifecycle.cs
+++ b/Patches/ScopeLifecycle.cs
@@ -764,6 +764,7 @@ namespace PiPDisabler
             // On fresh scope enter, forcing RestoreFov() can stomp EFT's own optic zoom
             // for bypassed scopes until the next zoom/mode event. Let vanilla drive FOV
             // immediately on enter, but still restore when switching from a modded mode.
+            PiPDisabler.CleanupVanillaOpticState(os);
             if (restoreFov)
                 RestoreFov();
             Patches.WeaponScalingPatch.RestoreScale();
@@ -814,14 +815,10 @@ namespace PiPDisabler
             PiPDisablerPlugin.LogInfo(
                 $"[ScopeLifecycle] ENTER: '{os.name}'[{FovController.GetOpticTemplateId(os)}] frame={Time.frameCount}");
 
-            // 1. Restore any black lens materials so ExtractReticle can read OpticSight textures.
-            //    (RestoreAll on previous scope-exit may have left sharedMaterials as Unlit/Color.)
-            LensTransparency.RestoreBlackLensMaterials();
-
-            // 2. Extract reticle texture BEFORE destroying lens mesh
+            // 1. Extract reticle texture BEFORE destroying lens mesh
             ReticleRenderer.ExtractReticle(os);
 
-            // 3. Hide ALL lens surfaces in the scope hierarchy (once)
+            // 2. Hide ALL lens surfaces in the scope hierarchy (once)
             LensTransparency.HideAllLensSurfaces(os);
 
             // 2b. Collect housing + weapon renderers for reticle stencil mask (lens surfaces
@@ -872,6 +869,7 @@ namespace PiPDisabler
             PiPDisablerPlugin.LogInfo(
                 $"[ScopeLifecycle] EXIT: '{(prevOptic != null ? prevOptic.name : "null")}'" +
                 $"[{FovController.GetOpticTemplateId(prevOptic)}] frame={Time.frameCount}");
+            PiPDisabler.CleanupVanillaOpticState(prevOptic);
 
             _isScoped = false;
             _activeOptic = null;

--- a/PiPDisablerPlugin.cs
+++ b/PiPDisablerPlugin.cs
@@ -127,7 +127,6 @@ namespace PiPDisabler
         internal static ConfigEntry<KeyCode> DisablePiPToggleKey;
         internal static ConfigEntry<bool> MakeLensesTransparent;
         internal static ConfigEntry<KeyCode> LensesTransparentToggleKey;
-        internal static ConfigEntry<bool> BlackLensWhenUnscoped;
 
         // --- Mesh Surgery ---
         internal static ConfigEntry<bool> EnableMeshSurgery;
@@ -297,14 +296,6 @@ namespace PiPDisabler
                     "Toggle key for lens transparency.",
                     null,
                     new ConfigurationManagerAttributes { IsAdvanced = true }));
-            BlackLensWhenUnscoped = Config.Bind("General", "BlackLensWhenUnscoped", true,
-                new ConfigDescription(
-                    "When unscoping, apply a solid black opaque material to the lens instead of restoring " +
-                "the original PiP/sight material. Eliminates the reticle flash during the unscope " +
-                "transition and gives the scope a realistic dark-glass appearance when not in use.",
-                    null,
-                    new ConfigurationManagerAttributes { IsAdvanced = true }));
-
             // --- Weapon Scaling ---
             EnableWeaponScaling = Config.Bind("General", "EnableWeaponScaling", true,
                 new ConfigDescription(
@@ -893,7 +884,7 @@ namespace PiPDisabler
             if (!ModEnabled.Value)
             {
                 ScopeLifecycle.ForceExit();
-                LensTransparency.FullRestoreAll(); // restore any lingering black lens materials
+                LensTransparency.FullRestoreAll();
                 PiPDisabler.RestoreAllCameras();
             }
             else


### PR DESCRIPTION
### Motivation
- Prevent red reticle/optic artifacts when PiP is disabled by performing the same vanilla optic shutdown cleanup (clear active optic, clear OpticRetrice state, force lens hidden) instead of only stopping PiP rendering.

### Description
- Add `CleanupVanillaOpticState(OpticSight)` in `Patches/PiPDisabler.cs` which finds `CameraClass.Instance?.OpticCameraManager`, sets `CurrentOpticSight = null`, calls `OpticRetrice.SetOpticSight(null)` and `OpticRetrice.Clear()`, and temporarily allows `opticSight.LensFade(true)` to run through the `OpticSight.LensFade` Harmony prefix.
- Invoke `CleanupVanillaOpticState` where needed: when bypassing back to vanilla during ADS (`ApplyBypassState`) and on scope exit (`DoScopeExit`) in `Patches/ScopeLifecycle.cs` so the reticle/renderer/command-buffer paths are torn down properly.
- Remove the unscoped black-lens option and its related black-material plumbing by deleting the `BlackLensWhenUnscoped` config and simplifying `Patches/LensTransparency.cs` to restore original materials on unscope rather than swapping to a black material.
- Add a small gate (`ShouldAllowForcedLensFade`) and allow the `OpticSight.LensFade` prefix to pass when the cleanup helper needs to force `LensFade(true)`.

### Testing
- Ran `git diff --check` to validate diff hygiene (succeeded).
- Attempted to run `dotnet build PiPDisabler.csproj` but the environment does not have `dotnet` installed, so a full compile was not performed (failed due to missing tool).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c11d2281d08328b79ba543ad209917)